### PR TITLE
chore: regenerate CRDs and update shortName to 'rgd'

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -141,7 +141,7 @@ type Dependency struct {
 // +kubebuilder:printcolumn:name="STATE",type=string,priority=0,JSONPath=`.status.state`
 // +kubebuilder:printcolumn:name="TOPOLOGICALORDER",type=string,priority=1,JSONPath=`.status.topologicalOrder`
 // +kubebuilder:printcolumn:name="AGE",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:shortName=rg
+// +kubebuilder:resource:shortName=rgd
 
 // ResourceGraphDefinition is the Schema for the resourcegraphdefinitions API
 type ResourceGraphDefinition struct {

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: ResourceGraphDefinitionList
     plural: resourcegraphdefinitions
     shortNames:
-    - rg
+    - rgd
     singular: resourcegraphdefinition
   scope: Namespaced
   versions:
@@ -36,7 +36,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceGraphDefinition is the Schema for the resourcegraphdefinitions API
+        description: ResourceGraphDefinition is the Schema for the resourcegraphdefinitions
+          API
         properties:
           apiVersion:
             description: |-
@@ -56,7 +57,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ResourceGraphDefinitionSpec defines the desired state of ResourceGraphDefinition
+            description: ResourceGraphDefinitionSpec defines the desired state of
+              ResourceGraphDefinition
             properties:
               defaultServiceAccounts:
                 additionalProperties:
@@ -147,7 +149,8 @@ spec:
             - schema
             type: object
           status:
-            description: ResourceGraphDefinitionStatus defines the observed state of ResourceGraphDefinition
+            description: ResourceGraphDefinitionStatus defines the observed state
+              of ResourceGraphDefinition
             properties:
               conditions:
                 description: Conditions represent the latest available observations

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: ResourceGraphDefinitionList
     plural: resourcegraphdefinitions
     shortNames:
-    - rg
+    - rgd
     singular: resourcegraphdefinition
   scope: Namespaced
   versions:
@@ -36,7 +36,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceGraphDefinition is the Schema for the resourcegraphdefinitions API
+        description: ResourceGraphDefinition is the Schema for the resourcegraphdefinitions
+          API
         properties:
           apiVersion:
             description: |-
@@ -56,7 +57,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ResourceGraphDefinitionSpec defines the desired state of ResourceGraphDefinition
+            description: ResourceGraphDefinitionSpec defines the desired state of
+              ResourceGraphDefinition
             properties:
               defaultServiceAccounts:
                 additionalProperties:
@@ -147,7 +149,8 @@ spec:
             - schema
             type: object
           status:
-            description: ResourceGraphDefinitionStatus defines the observed state of ResourceGraphDefinition
+            description: ResourceGraphDefinitionStatus defines the observed state
+              of ResourceGraphDefinition
             properties:
               conditions:
                 description: Conditions represent the latest available observations


### PR DESCRIPTION
Previous commit renamed the CRD but the author forgot to regenerate
the manifests. This commit:
- Regenerates CRD manifests for the previous rename
- Updates shortName from 'rg' to 'rgd'