### PR TITLE
chore: update copyright headers to Kube Resource Orchestrator

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/hack/update-license.sh
+++ b/hack/update-license.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+OLD_COPYRIGHT="$1"
+NEW_COPYRIGHT="// Copyright 2025 The Kube Resource Orchestrator Authors."
+
+# Find all .go files in the specified directories
+find ./cmd ./pkg ./test ./hack -name "*.go" -type f | while read -r file; do
+    if grep -q "$OLD_COPYRIGHT" "$file"; then
+        # Create a backup with .bak extension
+        cp "$file" "$file.bak"
+        
+        # Replace the copyright line
+        sed "s|$OLD_COPYRIGHT|$NEW_COPYRIGHT|" "$file.bak" > "$file"
+        
+        echo "Updated copyright in: $file"
+        rm "$file.bak"
+    fi
+done
+
+echo "Copyright update complete!"

--- a/pkg/cel/ast/inspector.go
+++ b/pkg/cel/ast/inspector.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/cel/ast/inspector_test.go
+++ b/pkg/cel/ast/inspector_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/controller_reconcile.go
+++ b/pkg/controller/instance/controller_reconcile.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/controller_status.go
+++ b/pkg/controller/instance/controller_status.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/delta/delta.go
+++ b/pkg/controller/instance/delta/delta.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/delta/delta_test.go
+++ b/pkg/controller/instance/delta/delta_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/instance_state.go
+++ b/pkg/controller/instance/instance_state.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/instance/metrics.go
+++ b/pkg/controller/instance/metrics.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/dynamiccontroller/metrics.go
+++ b/pkg/dynamiccontroller/metrics.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/crd/defaults.go
+++ b/pkg/graph/crd/defaults.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/dag/dag.go
+++ b/pkg/graph/dag/dag.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/fieldpath/builder.go
+++ b/pkg/graph/fieldpath/builder.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/fieldpath/builder_test.go
+++ b/pkg/graph/fieldpath/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/fieldpath/parser.go
+++ b/pkg/graph/fieldpath/parser.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/fieldpath/parser_test.go
+++ b/pkg/graph/fieldpath/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/cel.go
+++ b/pkg/graph/parser/cel.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/cel_test.go
+++ b/pkg/graph/parser/cel_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/conditions.go
+++ b/pkg/graph/parser/conditions.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/conditions_test.go
+++ b/pkg/graph/parser/conditions_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/parser.go
+++ b/pkg/graph/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/parser_test.go
+++ b/pkg/graph/parser/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/schemaless.go
+++ b/pkg/graph/parser/schemaless.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/parser/schemaless_test.go
+++ b/pkg/graph/parser/schemaless_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/resource.go
+++ b/pkg/graph/resource.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/resource_test.go
+++ b/pkg/graph/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/schema/conversion_cel.go
+++ b/pkg/graph/schema/conversion_cel.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/schema/conversion_schema.go
+++ b/pkg/graph/schema/conversion_schema.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/schema/field_descriptor.go
+++ b/pkg/graph/schema/field_descriptor.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/schema/resolver.go
+++ b/pkg/graph/schema/resolver.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/schema/schema.go
+++ b/pkg/graph/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/graph/variable/variable.go
+++ b/pkg/graph/variable/variable.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/finalizers.go
+++ b/pkg/metadata/finalizers.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/finalizers_test.go
+++ b/pkg/metadata/finalizers_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/groupversion_test.go
+++ b/pkg/metadata/groupversion_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/owner_reference.go
+++ b/pkg/metadata/owner_reference.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/metadata/selectors.go
+++ b/pkg/metadata/selectors.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/requeue/requeue.go
+++ b/pkg/requeue/requeue.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/resolver/resolver.go
+++ b/pkg/runtime/resolver/resolver.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/resolver/resolver_test.go
+++ b/pkg/runtime/resolver/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/runtime/state.go
+++ b/pkg/runtime/state.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/atomic.go
+++ b/pkg/simpleschema/atomic.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/atomic_test.go
+++ b/pkg/simpleschema/atomic_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/doc.go
+++ b/pkg/simpleschema/doc.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/field.go
+++ b/pkg/simpleschema/field.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/field_test.go
+++ b/pkg/simpleschema/field_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/markers.go
+++ b/pkg/simpleschema/markers.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/markers_test.go
+++ b/pkg/simpleschema/markers_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/simplerschema.go
+++ b/pkg/simpleschema/simplerschema.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/testutil/generator/resourcegraphdefinition.go
+++ b/pkg/testutil/generator/resourcegraphdefinition.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/pkg/testutil/k8s/discovery.go
+++ b/pkg/testutil/k8s/discovery.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/ackekscluster/generator.go
+++ b/test/integration/suites/ackekscluster/generator.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/ackekscluster/suite_test.go
+++ b/test/integration/suites/ackekscluster/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/conditional_test.go
+++ b/test/integration/suites/core/conditional_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/garbage_collection_test.go
+++ b/test/integration/suites/core/garbage_collection_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/lifecycle_test.go
+++ b/test/integration/suites/core/lifecycle_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/recover_test.go
+++ b/test/integration/suites/core/recover_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/setup_test.go
+++ b/test/integration/suites/core/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/status_test.go
+++ b/test/integration/suites/core/status_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/topology_test.go
+++ b/test/integration/suites/core/topology_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/deploymentservice/generator.go
+++ b/test/integration/suites/deploymentservice/generator.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/deploymentservice/suite_test.go
+++ b/test/integration/suites/deploymentservice/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/networkingstack/generator.go
+++ b/test/integration/suites/networkingstack/generator.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/test/integration/suites/networkingstack/suite_test.go
+++ b/test/integration/suites/networkingstack/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// Copyright 2025 The Kube Resource Orchestrator Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
Change all file copyright headers from "Copyright Amazon.com Inc. or its affiliates"
to "Copyright 2025 The Kube Resource Orchestrator Authors" while maintaining the
same Apache 2.0 license terms. This updates the copyright notices across all Go
files in cmd/, pkg/, and test/ directories to reflect the project's new
ownership.