### PR TITLE
refactor: complete ResourceGroup to ResourceGraphDefinition rename in code

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -96,13 +96,13 @@ type Resource struct {
 	IncludeWhen []string `json:"includeWhen,omitempty"`
 }
 
-// ResourceGraphDefinitionState defines the state of the resource group.
+// ResourceGraphDefinitionState defines the state of the resource graph definition.
 type ResourceGraphDefinitionState string
 
 const (
-	// ResourceGraphDefinitionStateActive represents the active state of the resource group.
+	// ResourceGraphDefinitionStateActive represents the active state of the resource definition.
 	ResourceGraphDefinitionStateActive ResourceGraphDefinitionState = "Active"
-	// ResourceGraphDefinitionStateInactive represents the inactive state of the resource group
+	// ResourceGraphDefinitionStateInactive represents the inactive state of the resource graph definition
 	ResourceGraphDefinitionStateInactive ResourceGraphDefinitionState = "Inactive"
 )
 
@@ -123,7 +123,7 @@ type ResourceGraphDefinitionStatus struct {
 type ResourceInformation struct {
 	// ID represents the id of the resources we're providing information for
 	ID string `json:"id,omitempty"`
-	// Dependencies represents the resource dependencies of a resource group
+	// Dependencies represents the resource dependencies of a resource graph definition
 	Dependencies []Dependency `json:"dependencies,omitempty"`
 }
 

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -202,7 +202,7 @@ spec:
                   properties:
                     dependencies:
                       description: Dependencies represents the resource dependencies
-                        of a resource group
+                        of a resource graph definition
                       items:
                         description: |-
                           Dependency defines the dependency a resource has observed

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -202,7 +202,7 @@ spec:
                   properties:
                     dependencies:
                       description: Dependencies represents the resource dependencies
-                        of a resource group
+                        of a resource graph definition
                       items:
                         description: |-
                           Dependency defines the dependency a resource has observed

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: KRO_HEALTH_PROBE_BIND_ADDRESS
               value: {{ .Values.config.healthProbeBindAddress | quote }}
             - name: KRO_RESOURCE_GROUP_CONCURRENT_RECONCILES
-              value: {{ .Values.config.resourceGroupConcurrentReconciles | quote }}
+              value: {{ .Values.config.resourceGraphDefinitionConcurrentReconciles | quote }}
             - name: KRO_DYNAMIC_CONTROLLER_CONCURRENT_RECONCILES
               value: {{ .Values.config.dynamicControllerConcurrentReconciles | quote }}
             - name: KRO_LOG_LEVEL
@@ -60,7 +60,7 @@ spec:
             - "$(KRO_METRICS_BIND_ADDRESS)"
             - --health-probe-bind-address
             - "$(KRO_HEALTH_PROBE_BIND_ADDRESS)"
-            - --resource-group-concurrent-reconciles
+            - --resource-graph-definition-concurrent-reconciles
             - "$(KRO_RESOURCE_GROUP_CONCURRENT_RECONCILES)"
             - --dynamic-controller-concurrent-reconciles
             - "$(KRO_DYNAMIC_CONTROLLER_CONCURRENT_RECONCILES)"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -82,8 +82,8 @@ config:
   metricsBindAddress: :8078
   # The address the probe endpoint binds to
   healthProbeBindAddress: :8079
-  # The number of resource group reconciles to run in parallel
-  resourceGroupConcurrentReconciles: 1
+  # The number of resource graph definition reconciles to run in parallel
+  resourceGraphDefinitionConcurrentReconciles: 1
   # The number of dynamic controller reconciles to run in parallel
   dynamicControllerConcurrentReconciles: 1
   # The log level verbosity. 0 is the least verbose, 5 is the most verbose

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -129,12 +129,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) error {
 
 	// This is one of the main reasons why we're splitting the controller into
 	// two parts. The instanciator is responsible for creating a new runtime
-	// instance of the resource group. The instance graph reconciler is responsible
+	// instance of the resource graph definition. The instance graph reconciler is responsible
 	// for reconciling the instance and its sub-resources, while keeping the same
 	// runtime object in it's fields.
 	rgRuntime, err := c.rgd.NewGraphRuntime(instance)
 	if err != nil {
-		return fmt.Errorf("failed to create runtime resource group: %w", err)
+		return fmt.Errorf("failed to create runtime resource graph definition: %w", err)
 	}
 
 	instanceSubResourcesLabeler, err := metadata.NewInstanceLabeler(instance).Merge(c.instanceLabeler)

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -62,7 +62,7 @@ func NewResourceGraphDefinitionReconciler(
 	crdWrapper := clientSet.CRD(kroclient.CRDWrapperConfig{
 		Log: log,
 	})
-	rgLogger := log.WithName("controller.resourceGroup")
+	rgLogger := log.WithName("controller.resourceGraphDefinition")
 
 	return &ResourceGraphDefinitionReconciler{
 		rootLogger:        log,
@@ -103,7 +103,7 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(ctx context.Context, resou
 		return ctrl.Result{}, nil
 	}
 
-	rlog.V(1).Info("Setting resource group as managed")
+	rlog.V(1).Info("Setting resource graph definition as managed")
 	if err := r.setManaged(ctx, resourcegraphdefinition); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -32,7 +32,7 @@ import (
 // 2. Deletes the associated CRD (if CRD deletion is enabled)
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
 	log, _ := logr.FromContext(ctx)
-	log.V(1).Info("cleaning up resource group", "name", rgd.Name)
+	log.V(1).Info("cleaning up resource graph definition", "name", rgd.Name)
 
 	// shutdown microcontroller
 	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -41,7 +41,7 @@ func NewStatusProcessor() *StatusProcessor {
 	}
 }
 
-// setDefaultConditions sets the default conditions for an active resource group
+// setDefaultConditions sets the default conditions for an active resource graph definition
 func (sp *StatusProcessor) setDefaultConditions() {
 	sp.conditions = []v1alpha1.Condition{
 		newReconcilerReadyCondition(metav1.ConditionTrue, ""),
@@ -90,7 +90,7 @@ func (r *ResourceGraphDefinitionReconciler) setResourceGraphDefinitionStatus(
 	reconcileErr error,
 ) error {
 	log, _ := logr.FromContext(ctx)
-	log.V(1).Info("calculating resource group status and conditions")
+	log.V(1).Info("calculating resource graph definition status and conditions")
 
 	processor := NewStatusProcessor()
 
@@ -120,7 +120,7 @@ func (r *ResourceGraphDefinitionReconciler) setResourceGraphDefinitionStatus(
 		// Get fresh copy to avoid conflicts
 		current := &v1alpha1.ResourceGraphDefinition{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(resourcegraphdefinition), current); err != nil {
-			return fmt.Errorf("failed to get current resource group: %w", err)
+			return fmt.Errorf("failed to get current resource graph definition: %w", err)
 		}
 
 		// Update status
@@ -130,7 +130,7 @@ func (r *ResourceGraphDefinitionReconciler) setResourceGraphDefinitionStatus(
 		dc.Status.TopologicalOrder = topologicalOrder
 		dc.Status.Resources = resources
 
-		log.V(1).Info("updating resource group status",
+		log.V(1).Info("updating resource graph definition status",
 			"state", dc.Status.State,
 			"conditions", len(dc.Status.Conditions),
 		)

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -35,14 +35,14 @@ func TestGraphBuilder_Validation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		resourceGroupOpts []generator.ResourceGraphDefinitionOption
-		wantErr           bool
-		errMsg            string
+		name                        string
+		resourceGraphDefinitionOpts []generator.ResourceGraphDefinitionOption
+		wantErr                     bool
+		errMsg                      string
 	}{
 		{
 			name: "invalid resource type",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -63,7 +63,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid resource id with operator",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -84,7 +84,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "resource without a valid GVK",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -101,7 +101,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid CEL syntax in readyWhen",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -122,7 +122,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid CEL syntax in includeWhen expression",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -143,7 +143,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "missing required field",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -165,7 +165,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid field reference",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -189,7 +189,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "valid VPC with valid conditional subnets",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -236,7 +236,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid resource type",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -257,7 +257,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid instance spec field type",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -271,7 +271,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid instance status field reference",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -294,7 +294,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "invalid field type in resource spec",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -318,7 +318,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "crds aren't allowed to have variables in their spec fields",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -350,7 +350,7 @@ func TestGraphBuilder_Validation(t *testing.T) {
 		},
 		{
 			name: "valid instance definition with complex types",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -381,8 +381,8 @@ func TestGraphBuilder_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rg := generator.NewResourceGraphDefinition("test-group", tt.resourceGroupOpts...)
-			_, err := builder.NewResourceGraphDefinition(rg)
+			rgd := generator.NewResourceGraphDefinition("test-group", tt.resourceGraphDefinitionOpts...)
+			_, err := builder.NewResourceGraphDefinition(rgd)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -403,15 +403,15 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		resourceGroupOpts []generator.ResourceGraphDefinitionOption
-		wantErr           bool
-		errMsg            string
-		validateDeps      func(*testing.T, *Graph)
+		name                        string
+		resourceGraphDefinitionOpts []generator.ResourceGraphDefinitionOption
+		wantErr                     bool
+		errMsg                      string
+		validateDeps                func(*testing.T, *Graph)
 	}{
 		{
 			name: "complex eks setup dependencies",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -514,7 +514,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 		},
 		{
 			name: "missing dependency",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -539,7 +539,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 		},
 		{
 			name: "cyclic dependency",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -575,7 +575,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 		},
 		{
 			name: "independent pods",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -656,7 +656,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 		},
 		{
 			name: "cyclic pod dependencies",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -730,7 +730,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 		},
 		{
 			name: "shared infrastructure dependencies",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -937,8 +937,8 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rg := generator.NewResourceGraphDefinition("testgroup", tt.resourceGroupOpts...)
-			g, err := builder.NewResourceGraphDefinition(rg)
+			rgd := generator.NewResourceGraphDefinition("testrgd", tt.resourceGraphDefinitionOpts...)
+			g, err := builder.NewResourceGraphDefinition(rgd)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -963,13 +963,13 @@ func TestGraphBuilder_ExpressionParsing(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		resourceGroupOpts []generator.ResourceGraphDefinitionOption
-		validateVars      func(*testing.T, *Graph)
+		name                        string
+		resourceGraphDefinitionOpts []generator.ResourceGraphDefinitionOption
+		validateVars                func(*testing.T, *Graph)
 	}{
 		{
 			name: "complex resource variable parsing",
-			resourceGroupOpts: []generator.ResourceGraphDefinitionOption{
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(
 					"Test", "v1alpha1",
 					map[string]interface{}{
@@ -1187,8 +1187,8 @@ func TestGraphBuilder_ExpressionParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rg := generator.NewResourceGraphDefinition("testgroup", tt.resourceGroupOpts...)
-			g, err := builder.NewResourceGraphDefinition(rg)
+			rgd := generator.NewResourceGraphDefinition("testrgd", tt.resourceGraphDefinitionOpts...)
+			g, err := builder.NewResourceGraphDefinition(rgd)
 			require.NoError(t, err)
 			if tt.validateVars != nil {
 				tt.validateVars(t, g)

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -21,19 +21,19 @@ import (
 )
 
 // Graph represents a processed resourcegraphdefinition. It contains the DAG representation
-// and everything needed to "manage" the resources defined in the resource group.
+// and everything needed to "manage" the resources defined in the resource graph definition.
 type Graph struct {
-	// DAG is the directed acyclic graph representation of the resource group.
+	// DAG is the directed acyclic graph representation of the resource graph definition.
 	DAG *dag.DirectedAcyclicGraph
-	// Instance is the processed resource group instance.
+	// Instance is the processed resource graph definition instance.
 	Instance *Resource
-	// Resources is a map of the processed resources in the resource group.
+	// Resources is a map of the processed resources in the resource graph definition.
 	Resources map[string]*Resource
-	// TopologicalOrder is the topological order of the resources in the resource group.
+	// TopologicalOrder is the topological order of the resources in the resource graph definition.
 	TopologicalOrder []string
 }
 
-// NewGraphRuntime creates a new runtime resource group from the resource group instance.
+// NewGraphRuntime creates a new runtime resource graph definition from the resource graph definition instance.
 func (rgd *Graph) NewGraphRuntime(newInstance *unstructured.Unstructured) (*runtime.ResourceGraphDefinitionRuntime, error) {
 	// we need to copy the resources to the runtime resources, mainly focusing
 	// on the variables and dependencies.

--- a/pkg/graph/resource.go
+++ b/pkg/graph/resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kro-run/kro/pkg/graph/variable"
 )
 
-// Resource represents a resource in a resource group, it hholds
+// Resource represents a resource in a resource graph definition, it hholds
 // information about the resource, its schema, and its variables.
 //
 // This object can only be created by the GraphBuilder and it should
@@ -33,8 +33,8 @@ import (
 // modified after creation.
 type Resource struct {
 	// id is the unique identifier of the resource. It's the name of the
-	// resource in the resource group.
-	// An id is unique within a resource group, and adheres to the naming
+	// resource in the resource graph definition.
+	// An id is unique within a resource graph definition, and adheres to the naming
 	// conventions.
 	id string
 	// GroupVersionKind is the GVK of the resource.
@@ -43,7 +43,7 @@ type Resource struct {
 	schema *spec.Schema
 	// SchemaExt is similar to Schema but can be used to create a CRD.
 	crd *extv1.CustomResourceDefinition
-	// Original represents the original object we found in the resource group.
+	// Original represents the original object we found in the resource graph definition.
 	// This will contain all fields (and CEL expressions) as they were in the
 	// original object.
 	originalObject *unstructured.Unstructured
@@ -64,7 +64,7 @@ type Resource struct {
 	// before the resource is considered ready.
 	readyWhenExpressions []string
 	// includeWhenExpressions is a list of the expresisons that need to be evaluated
-	// to decide whether to create a resource group or not
+	// to decide whether to create a resource graph definition or not
 	includeWhenExpressions []string
 	// namespaced indicates if the resource is namespaced or cluster-scoped.
 	// This is useful when initiating the dynamic client to interact with the
@@ -116,7 +116,7 @@ func (r *Resource) GetCRD() *extv1.CustomResourceDefinition {
 	return r.crd.DeepCopy()
 }
 
-// Unstructured returns the original object we found in the resource group.
+// Unstructured returns the original object we found in the resource graph definition.
 func (r *Resource) Unstructured() *unstructured.Unstructured {
 	return r.originalObject
 }

--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -84,7 +84,7 @@ func isKROReservedWord(word string) bool {
 }
 
 // validateResourceGraphDefinitionNamingConventions validates the naming conventions of
-// the given resource group.
+// the given resource graph definition.
 func validateResourceGraphDefinitionNamingConventions(rgd *v1alpha1.ResourceGraphDefinition) error {
 	if !isValidKindName(rgd.Spec.Schema.Kind) {
 		return fmt.Errorf("%s: kind '%s' is not a valid KRO kind name: must be UpperCamelCase", ErrNamingConvention, rgd.Spec.Schema.Kind)

--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -22,12 +22,12 @@ import (
 func TestValidateRGResourceNames(t *testing.T) {
 	tests := []struct {
 		name        string
-		rg          *v1alpha1.ResourceGraphDefinition
+		rgd         *v1alpha1.ResourceGraphDefinition
 		expectError bool
 	}{
 		{
-			name: "Valid resource group resource ids",
-			rg: &v1alpha1.ResourceGraphDefinition{
+			name: "Valid resource graph definition resource ids",
+			rgd: &v1alpha1.ResourceGraphDefinition{
 				Spec: v1alpha1.ResourceGraphDefinitionSpec{
 					Resources: []*v1alpha1.Resource{
 						{ID: "validID1"},
@@ -39,7 +39,7 @@ func TestValidateRGResourceNames(t *testing.T) {
 		},
 		{
 			name: "Duplicate resource ids",
-			rg: &v1alpha1.ResourceGraphDefinition{
+			rgd: &v1alpha1.ResourceGraphDefinition{
 				Spec: v1alpha1.ResourceGraphDefinitionSpec{
 					Resources: []*v1alpha1.Resource{
 						{ID: "duplicateID"},
@@ -51,7 +51,7 @@ func TestValidateRGResourceNames(t *testing.T) {
 		},
 		{
 			name: "Invalid resource ID",
-			rg: &v1alpha1.ResourceGraphDefinition{
+			rgd: &v1alpha1.ResourceGraphDefinition{
 				Spec: v1alpha1.ResourceGraphDefinitionSpec{
 					Resources: []*v1alpha1.Resource{
 						{ID: "Invalid_ID"},
@@ -62,7 +62,7 @@ func TestValidateRGResourceNames(t *testing.T) {
 		},
 		{
 			name: "Reserved word as resource id",
-			rg: &v1alpha1.ResourceGraphDefinition{
+			rgd: &v1alpha1.ResourceGraphDefinition{
 				Spec: v1alpha1.ResourceGraphDefinitionSpec{
 					Resources: []*v1alpha1.Resource{
 						{ID: "spec"},
@@ -75,7 +75,7 @@ func TestValidateRGResourceNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateResourceIDs(tt.rg)
+			err := validateResourceIDs(tt.rgd)
 			if (err != nil) != tt.expectError {
 				t.Errorf("validateRGResourceIDs() error = %v, expectError %v", err, tt.expectError)
 			}
@@ -91,7 +91,7 @@ func TestIsKROReservedWord(t *testing.T) {
 		{"resourcegraphdefinition", true},
 		{"instance", true},
 		{"notReserved", false},
-		{"RESOURCEGROUP", false}, // Case-sensitive check
+		{"RESOURCEGRAPHDEFINITION", false}, // Case-sensitive check
 	}
 
 	for _, tt := range tests {

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -37,10 +37,10 @@ const (
 	InstanceLabel          = LabelKroPrefix + "instance-name"
 	InstanceNamespaceLabel = LabelKroPrefix + "instance-namespace"
 
-	ResourceGraphDefinitionIDLabel        = LabelKroPrefix + "resource-group-id"
-	ResourceGraphDefinitionNameLabel      = LabelKroPrefix + "resource-group-name"
-	ResourceGraphDefinitionNamespaceLabel = LabelKroPrefix + "resource-group-namespace"
-	ResourceGraphDefinitionVersionLabel   = LabelKroPrefix + "resource-group-version"
+	ResourceGraphDefinitionIDLabel        = LabelKroPrefix + "resource-graph-definition-id"
+	ResourceGraphDefinitionNameLabel      = LabelKroPrefix + "resource-graph-definition-name"
+	ResourceGraphDefinitionNamespaceLabel = LabelKroPrefix + "resource-graph-definition-namespace"
+	ResourceGraphDefinitionVersionLabel   = LabelKroPrefix + "resource-graph-definition-version"
 )
 
 // IsKroOwned returns true if the resource is owned by Kro.

--- a/pkg/metadata/selectors.go
+++ b/pkg/metadata/selectors.go
@@ -15,7 +15,7 @@ package metadata
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// Sometimes we need to search for resources that belong to given instance, resource group or node.
+// Sometimes we need to search for resources that belong to given instance, resource graph definition or node.
 // This is helpful to for garbage collection of resources that are no longer needed, or got
 // orphaned due to graph evolutions.
 
@@ -29,31 +29,31 @@ func NewInstanceSelector(instance metav1.Object) metav1.LabelSelector {
 	}
 }
 
-func NewResourceGraphDefinitionSelector(resourceGroup metav1.Object) metav1.LabelSelector {
+func NewResourceGraphDefinitionSelector(resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			ResourceGraphDefinitionIDLabel: string(resourceGroup.GetUID()),
-			// ResourceGraphDefinitionNameLabel:      resourceGroup.GetName(),
-			// ResourceGraphDefinitionNamespaceLabel: resourceGroup.GetNamespace(),
+			ResourceGraphDefinitionIDLabel: string(resourceGraphDefinition.GetUID()),
+			// ResourceGraphDefinitionNameLabel:      resourceGraphDefinition.GetName(),
+			// ResourceGraphDefinitionNamespaceLabel: resourceGraphDefinition.GetNamespace(),
 		},
 	}
 }
 
-func NewInstanceAndResourceGraphDefinitionSelector(instance metav1.Object, resourceGroup metav1.Object) metav1.LabelSelector {
+func NewInstanceAndResourceGraphDefinitionSelector(instance metav1.Object, resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			InstanceIDLabel:                string(instance.GetUID()),
-			ResourceGraphDefinitionIDLabel: string(resourceGroup.GetUID()),
+			ResourceGraphDefinitionIDLabel: string(resourceGraphDefinition.GetUID()),
 		},
 	}
 }
 
-func NewNodeAndInstanceAndResourceGraphDefinitionSelector(node metav1.Object, instance metav1.Object, resourceGroup metav1.Object) metav1.LabelSelector {
+func NewNodeAndInstanceAndResourceGraphDefinitionSelector(node metav1.Object, instance metav1.Object, resourceGraphDefinition metav1.Object) metav1.LabelSelector {
 	return metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			NodeIDLabel:                    node.GetName(),
 			InstanceIDLabel:                string(instance.GetUID()),
-			ResourceGraphDefinitionIDLabel: string(resourceGroup.GetUID()),
+			ResourceGraphDefinitionIDLabel: string(resourceGraphDefinition.GetUID()),
 		},
 	}
 }

--- a/pkg/testutil/generator/resourcegraphdefinition.go
+++ b/pkg/testutil/generator/resourcegraphdefinition.go
@@ -28,16 +28,16 @@ type ResourceGraphDefinitionOption func(*krov1alpha1.ResourceGraphDefinition)
 
 // NewResourceGraphDefinition creates a new ResourceGraphDefinition with the given name and options
 func NewResourceGraphDefinition(name string, opts ...ResourceGraphDefinitionOption) *krov1alpha1.ResourceGraphDefinition {
-	rg := &krov1alpha1.ResourceGraphDefinition{
+	rgd := &krov1alpha1.ResourceGraphDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 
 	for _, opt := range opts {
-		opt(rg)
+		opt(rgd)
 	}
-	return rg
+	return rgd
 }
 
 // WithNamespace sets the namespace of the ResourceGraphDefinition

--- a/test/integration/suites/ackekscluster/suite_test.go
+++ b/test/integration/suites/ackekscluster/suite_test.go
@@ -71,24 +71,24 @@ var _ = Describe("EKSCluster", func() {
 		Expect(env.Client.Create(ctx, ns)).To(Succeed())
 
 		// Create ResourceGraphDefinition
-		rg, genInstance := eksCluster(namespace, "test-eks-cluster")
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		rgd, genInstance := eksCluster(namespace, "test-eks-cluster")
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is created and becomes ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify the ResourceGraphDefinition fields
-			g.Expect(createdRG.Spec.Schema.Kind).To(Equal("EKSCluster"))
-			g.Expect(createdRG.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
-			g.Expect(createdRG.Spec.Resources).To(HaveLen(12)) // All resources from the generator
+			g.Expect(createdRGD.Spec.Schema.Kind).To(Equal("EKSCluster"))
+			g.Expect(createdRGD.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
+			g.Expect(createdRGD.Spec.Resources).To(HaveLen(12)) // All resources from the generator
 
-			g.Expect(createdRG.Status.TopologicalOrder).To(Equal([]string{
+			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"clusterRole",
 				"clusterVPC",
 				"clusterInternetGateway",
@@ -104,22 +104,22 @@ var _ = Describe("EKSCluster", func() {
 			}))
 
 			// Verify the ResourceGraphDefinition status
-			g.Expect(createdRG.Status.TopologicalOrder).To(HaveLen(12))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(12))
 			// Verify conditions
-			g.Expect(createdRG.Status.Conditions).To(HaveLen(3))
-			g.Expect(createdRG.Status.Conditions[0].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions).To(HaveLen(3))
+			g.Expect(createdRGD.Status.Conditions[0].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeReconcilerReady,
 			))
-			g.Expect(createdRG.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[1].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[1].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified,
 			))
-			g.Expect(createdRG.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[2].Type).To(
+			g.Expect(createdRGD.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Type).To(
 				Equal(krov1alpha1.ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced),
 			)
-			g.Expect(createdRG.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 		}, 10*time.Second, time.Second).Should(Succeed())
 
 		// Create instance
@@ -469,12 +469,12 @@ var _ = Describe("EKSCluster", func() {
 		}, 60*time.Second, time.Second).Should(BeTrue())
 
 		// Delete ResourceGraphDefinition
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is deleted
 		Eventually(func() bool {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
 			}, &krov1alpha1.ResourceGraphDefinition{})
 			return errors.IsNotFound(err)

--- a/test/integration/suites/core/conditional_test.go
+++ b/test/integration/suites/core/conditional_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Conditions", func() {
 	})
 
 	It("should not create deployment, service, and configmap due to condition deploymentEnabled == false", func() {
-		rg := generator.NewResourceGraphDefinition("test-conditions",
+		rgd := generator.NewResourceGraphDefinition("test-conditions",
 			generator.WithNamespace(namespace),
 			generator.WithSchema(
 				"TestConditions", "v1alpha1",
@@ -196,23 +196,23 @@ var _ = Describe("Conditions", func() {
 		)
 
 		// Create ResourceGraphDefinition
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is created and becomes ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify the ResourceGraphDefinition fields
-			g.Expect(createdRG.Spec.Schema.Kind).To(Equal("TestConditions"))
-			g.Expect(createdRG.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
-			g.Expect(createdRG.Spec.Resources).To(HaveLen(6))
+			g.Expect(createdRGD.Spec.Schema.Kind).To(Equal("TestConditions"))
+			g.Expect(createdRGD.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
+			g.Expect(createdRGD.Spec.Resources).To(HaveLen(6))
 
-			g.Expect(createdRG.Status.TopologicalOrder).To(Equal([]string{
+			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"deploymentA",
 				"serviceAccountA",
 				"deploymentB",
@@ -222,22 +222,22 @@ var _ = Describe("Conditions", func() {
 			}))
 
 			// Verify the ResourceGraphDefinition status
-			g.Expect(createdRG.Status.TopologicalOrder).To(HaveLen(6))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(6))
 			// Verify conditions
-			g.Expect(createdRG.Status.Conditions).To(HaveLen(3))
-			g.Expect(createdRG.Status.Conditions[0].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions).To(HaveLen(3))
+			g.Expect(createdRGD.Status.Conditions[0].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeReconcilerReady,
 			))
-			g.Expect(createdRG.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[1].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[1].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified,
 			))
-			g.Expect(createdRG.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[2].Type).To(
+			g.Expect(createdRGD.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Type).To(
 				Equal(krov1alpha1.ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced),
 			)
-			g.Expect(createdRG.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 
 		}, 10*time.Second, time.Second).Should(Succeed())
 
@@ -349,12 +349,12 @@ var _ = Describe("Conditions", func() {
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
 		// Delete ResourceGraphDefinition
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is deleted
 		Eventually(func() bool {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
 			}, &krov1alpha1.ResourceGraphDefinition{})
 			return errors.IsNotFound(err)

--- a/test/integration/suites/core/crd_test.go
+++ b/test/integration/suites/core/crd_test.go
@@ -49,7 +49,7 @@ var _ = Describe("CRD", func() {
 	Context("CRD Creation", func() {
 		It("should create CRD when ResourceGraphDefinition is created", func() {
 			// Create a simple ResourceGraphDefinition
-			rg := generator.NewResourceGraphDefinition("test-crd",
+			rgd := generator.NewResourceGraphDefinition("test-crd",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestResource", "v1alpha1",
@@ -72,7 +72,7 @@ var _ = Describe("CRD", func() {
 				}, nil, nil),
 			)
 
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			// Verify CRD is created
 			crd := &apiextensionsv1.CustomResourceDefinition{}
@@ -99,7 +99,7 @@ var _ = Describe("CRD", func() {
 
 		It("should update CRD when ResourceGraphDefinition is updated", func() {
 			// Create initial ResourceGraphDefinition
-			rg := generator.NewResourceGraphDefinition("test-crd-update",
+			rgd := generator.NewResourceGraphDefinition("test-crd-update",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestUpdate", "v1alpha1",
@@ -110,7 +110,7 @@ var _ = Describe("CRD", func() {
 					nil,
 				),
 			)
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			// Wait for initial CRD
 			crd := &apiextensionsv1.CustomResourceDefinition{}
@@ -123,18 +123,18 @@ var _ = Describe("CRD", func() {
 			// Update ResourceGraphDefinition with new fields
 			Eventually(func(g Gomega) {
 				err := env.Client.Get(ctx, types.NamespacedName{
-					Name:      rg.Name,
+					Name:      rgd.Name,
 					Namespace: namespace,
-				}, rg)
+				}, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				rg.Spec.Schema.Spec = toRawExtension(map[string]interface{}{
+				rgd.Spec.Schema.Spec = toRawExtension(map[string]interface{}{
 					"field1": "string",
 					"field2": "integer | default=42",
 					"field3": "boolean",
 				})
 
-				err = env.Client.Update(ctx, rg)
+				err = env.Client.Update(ctx, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
 			}, 10*time.Second, time.Second).Should(Succeed())
 
@@ -153,7 +153,7 @@ var _ = Describe("CRD", func() {
 
 		It("should delete CRD when ResourceGraphDefinition is deleted", func() {
 			// Create ResourceGraphDefinition
-			rg := generator.NewResourceGraphDefinition("test-crd-delete",
+			rgd := generator.NewResourceGraphDefinition("test-crd-delete",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestDelete", "v1alpha1",
@@ -163,7 +163,7 @@ var _ = Describe("CRD", func() {
 					nil,
 				),
 			)
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			// Wait for CRD creation
 			crdName := "testdeletes.kro.run"
@@ -173,7 +173,7 @@ var _ = Describe("CRD", func() {
 			}, 10*time.Second, time.Second).Should(Succeed())
 
 			// Delete ResourceGraphDefinition
-			Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 			// Verify CRD is deleted
 			Eventually(func() bool {

--- a/test/integration/suites/core/lifecycle_test.go
+++ b/test/integration/suites/core/lifecycle_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Update", func() {
 		Expect(env.Client.Create(ctx, ns)).To(Succeed())
 
 		// Create ResourceGraphDefinition for a simple deployment service
-		rg := generator.NewResourceGraphDefinition("test-update",
+		rgd := generator.NewResourceGraphDefinition("test-update",
 			generator.WithNamespace(namespace),
 			generator.WithSchema(
 				"TestUpdate", "v1alpha1",
@@ -94,17 +94,17 @@ var _ = Describe("Update", func() {
 			}, nil, nil),
 		)
 
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 		}, 10*time.Second, time.Second).Should(Succeed())
 
 		// Create initial instance
@@ -183,7 +183,7 @@ var _ = Describe("Update", func() {
 			return errors.IsNotFound(err)
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		Expect(env.Client.Delete(ctx, ns)).To(Succeed())
 	})
 })

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Readiness", func() {
 
 	It(`should wait for deployment to have deployment.spec.replicas 
 		== deployment.status.availableReplicas before creating service`, func() {
-		rg := generator.NewResourceGraphDefinition("test-readiness",
+		rgd := generator.NewResourceGraphDefinition("test-readiness",
 			generator.WithNamespace(namespace),
 			generator.WithSchema(
 				"TestReadiness", "v1alpha1",
@@ -137,44 +137,44 @@ var _ = Describe("Readiness", func() {
 		)
 
 		// Create ResourceGraphDefinition
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is created and becomes ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify the ResourceGraphDefinition fields
-			g.Expect(createdRG.Spec.Schema.Kind).To(Equal("TestReadiness"))
-			g.Expect(createdRG.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
-			g.Expect(createdRG.Spec.Resources).To(HaveLen(2))
+			g.Expect(createdRGD.Spec.Schema.Kind).To(Equal("TestReadiness"))
+			g.Expect(createdRGD.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
+			g.Expect(createdRGD.Spec.Resources).To(HaveLen(2))
 
-			g.Expect(createdRG.Status.TopologicalOrder).To(Equal([]string{
+			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"deployment",
 				"service",
 			}))
 
 			// Verify the ResourceGraphDefinition status
-			g.Expect(createdRG.Status.TopologicalOrder).To(HaveLen(2))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(2))
 			// Verify conditions
-			g.Expect(createdRG.Status.Conditions).To(HaveLen(3))
-			g.Expect(createdRG.Status.Conditions[0].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions).To(HaveLen(3))
+			g.Expect(createdRGD.Status.Conditions[0].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeReconcilerReady,
 			))
-			g.Expect(createdRG.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[1].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[1].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified,
 			))
-			g.Expect(createdRG.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[2].Type).To(
+			g.Expect(createdRGD.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Type).To(
 				Equal(krov1alpha1.ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced),
 			)
-			g.Expect(createdRG.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 
 		}, 10*time.Second, time.Second).Should(Succeed())
 
@@ -281,12 +281,12 @@ var _ = Describe("Readiness", func() {
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
 		// Delete ResourceGraphDefinition
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is deleted
 		Eventually(func() bool {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
 			}, &krov1alpha1.ResourceGraphDefinition{})
 			return errors.IsNotFound(err)

--- a/test/integration/suites/core/status_test.go
+++ b/test/integration/suites/core/status_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Status", func() {
 	})
 
 	It("should have correct conditions when ResourceGraphDefinition is created", func() {
-		rg := generator.NewResourceGraphDefinition("test-status",
+		rgd := generator.NewResourceGraphDefinition("test-status",
 			generator.WithNamespace(namespace),
 			generator.WithSchema(
 				"TestStatus", "v1alpha1",
@@ -65,21 +65,21 @@ var _ = Describe("Status", func() {
 			}, nil, nil),
 		)
 
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition status
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, rg)
+			}, rgd)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Check conditions
-			g.Expect(rg.Status.Conditions).To(HaveLen(3))
-			g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(rgd.Status.Conditions).To(HaveLen(3))
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 
-			for _, cond := range rg.Status.Conditions {
+			for _, cond := range rgd.Status.Conditions {
 				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			}
 
@@ -87,7 +87,7 @@ var _ = Describe("Status", func() {
 	})
 
 	It("should reflect failure conditions when definition is invalid", func() {
-		rg := generator.NewResourceGraphDefinition("test-status-fail",
+		rgd := generator.NewResourceGraphDefinition("test-status-fail",
 			generator.WithNamespace(namespace),
 			generator.WithSchema(
 				"TestStatusFail", "v1alpha1",
@@ -98,20 +98,20 @@ var _ = Describe("Status", func() {
 			),
 		)
 
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, rg)
+			}, rgd)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 
 			// Check specific failure condition
 			var crdCondition *krov1alpha1.Condition
-			for _, cond := range rg.Status.Conditions {
+			for _, cond := range rgd.Status.Conditions {
 				if cond.Type == krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified {
 					crdCondition = &cond
 					break

--- a/test/integration/suites/core/validation_test.go
+++ b/test/integration/suites/core/validation_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Validation", func() {
 
 	Context("Resource IDs", func() {
 		It("should validate correct resource naming conventions", func() {
-			rg := generator.NewResourceGraphDefinition("test-validation",
+			rgd := generator.NewResourceGraphDefinition("test-validation",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestValidation", "v1alpha1",
@@ -62,15 +62,15 @@ var _ = Describe("Validation", func() {
 				generator.WithResource("testResource", validResourceDef(), nil, nil),
 			)
 
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := env.Client.Get(ctx, types.NamespacedName{
-					Name:      rg.Name,
+					Name:      rgd.Name,
 					Namespace: namespace,
-				}, rg)
+				}, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 			}, 10*time.Second, time.Second).Should(Succeed())
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Validation", func() {
 			}
 
 			for _, invalidName := range invalidNames {
-				rg := generator.NewResourceGraphDefinition(fmt.Sprintf("test-validation-%s", rand.String(5)),
+				rgd := generator.NewResourceGraphDefinition(fmt.Sprintf("test-validation-%s", rand.String(5)),
 					generator.WithNamespace(namespace),
 					generator.WithSchema(
 						"TestValidation", "v1alpha1",
@@ -101,19 +101,19 @@ var _ = Describe("Validation", func() {
 					generator.WithResource(invalidName, validResourceDef(), nil, nil),
 				)
 
-				Expect(env.Client.Create(ctx, rg)).To(Succeed())
+				Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					err := env.Client.Get(ctx, types.NamespacedName{
-						Name:      rg.Name,
+						Name:      rgd.Name,
 						Namespace: namespace,
-					}, rg)
+					}, rgd)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+					g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 
 					// Verify validation condition
 					var condition *krov1alpha1.Condition
-					for _, cond := range rg.Status.Conditions {
+					for _, cond := range rgd.Status.Conditions {
 						if cond.Type == krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified {
 							condition = &cond
 							break
@@ -127,7 +127,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should reject duplicate resource IDs", func() {
-			rg := generator.NewResourceGraphDefinition("test-validation-dup",
+			rgd := generator.NewResourceGraphDefinition("test-validation-dup",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestValidation", "v1alpha1",
@@ -140,19 +140,19 @@ var _ = Describe("Validation", func() {
 				generator.WithResource("myResource", validResourceDef(), nil, nil), // Duplicate
 			)
 
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := env.Client.Get(ctx, types.NamespacedName{
-					Name:      rg.Name,
+					Name:      rgd.Name,
 					Namespace: namespace,
-				}, rg)
+				}, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 
 				// Verify validation condition
 				var condition *krov1alpha1.Condition
-				for _, cond := range rg.Status.Conditions {
+				for _, cond := range rgd.Status.Conditions {
 					if cond.Type == krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified {
 						condition = &cond
 						break
@@ -167,7 +167,7 @@ var _ = Describe("Validation", func() {
 
 	Context("Kubernetes Object Structure", func() {
 		It("should validate correct kubernetes object structure", func() {
-			rg := generator.NewResourceGraphDefinition("test-k8s-valid",
+			rgd := generator.NewResourceGraphDefinition("test-k8s-valid",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestK8sValidation", "v1alpha1",
@@ -185,15 +185,15 @@ var _ = Describe("Validation", func() {
 				}, nil, nil),
 			)
 
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := env.Client.Get(ctx, types.NamespacedName{
-					Name:      rg.Name,
+					Name:      rgd.Name,
 					Namespace: namespace,
-				}, rg)
+				}, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 			}, 10*time.Second, time.Second).Should(Succeed())
 		})
 
@@ -229,7 +229,7 @@ var _ = Describe("Validation", func() {
 			}
 
 			for i, invalidObj := range invalidObjects {
-				rg := generator.NewResourceGraphDefinition(fmt.Sprintf("test-k8s-invalid-%d", i),
+				rgd := generator.NewResourceGraphDefinition(fmt.Sprintf("test-k8s-invalid-%d", i),
 					generator.WithNamespace(namespace),
 					generator.WithSchema(
 						"TestK8sValidation", "v1alpha1",
@@ -241,15 +241,15 @@ var _ = Describe("Validation", func() {
 					generator.WithResource("resource", invalidObj, nil, nil),
 				)
 
-				Expect(env.Client.Create(ctx, rg)).To(Succeed())
+				Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					err := env.Client.Get(ctx, types.NamespacedName{
-						Name:      rg.Name,
+						Name:      rgd.Name,
 						Namespace: namespace,
-					}, rg)
+					}, rgd)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+					g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 				}, 10*time.Second, time.Second).Should(Succeed())
 			}
 		})
@@ -265,7 +265,7 @@ var _ = Describe("Validation", func() {
 			}
 
 			for _, kind := range validKinds {
-				rg := generator.NewResourceGraphDefinition(fmt.Sprintf("test-kind-%s", rand.String(5)),
+				rgd := generator.NewResourceGraphDefinition(fmt.Sprintf("test-kind-%s", rand.String(5)),
 					generator.WithNamespace(namespace),
 					generator.WithSchema(
 						kind, "v1alpha1",
@@ -276,15 +276,15 @@ var _ = Describe("Validation", func() {
 					),
 				)
 
-				Expect(env.Client.Create(ctx, rg)).To(Succeed())
+				Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					err := env.Client.Get(ctx, types.NamespacedName{
-						Name:      rg.Name,
+						Name:      rgd.Name,
 						Namespace: namespace,
-					}, rg)
+					}, rgd)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+					g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 				}, 10*time.Second, time.Second).Should(Succeed())
 			}
 		})
@@ -300,7 +300,7 @@ var _ = Describe("Validation", func() {
 			}
 
 			for _, kind := range invalidKinds {
-				rg := generator.NewResourceGraphDefinition(fmt.Sprintf("test-kind-%s", rand.String(5)),
+				rgd := generator.NewResourceGraphDefinition(fmt.Sprintf("test-kind-%s", rand.String(5)),
 					generator.WithNamespace(namespace),
 					generator.WithSchema(
 						kind, "v1alpha1",
@@ -311,15 +311,15 @@ var _ = Describe("Validation", func() {
 					),
 				)
 
-				Expect(env.Client.Create(ctx, rg)).To(Succeed())
+				Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					err := env.Client.Get(ctx, types.NamespacedName{
-						Name:      rg.Name,
+						Name:      rgd.Name,
 						Namespace: namespace,
-					}, rg)
+					}, rgd)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+					g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 				}, 10*time.Second, time.Second).Should(Succeed())
 			}
 		})
@@ -327,7 +327,7 @@ var _ = Describe("Validation", func() {
 
 	Context("Proper Cleanup", func() {
 		It("should not panic when deleting an inactive ResourceGraphDefinition", func() {
-			rg := generator.NewResourceGraphDefinition("test-cleanup",
+			rgd := generator.NewResourceGraphDefinition("test-cleanup",
 				generator.WithNamespace(namespace),
 				generator.WithSchema(
 					"TestCleanup", "v1alpha1",
@@ -345,19 +345,19 @@ var _ = Describe("Validation", func() {
 				}, nil, nil),
 			)
 
-			Expect(env.Client.Create(ctx, rg)).To(Succeed())
+			Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := env.Client.Get(ctx, types.NamespacedName{
-					Name:      rg.Name,
+					Name:      rgd.Name,
 					Namespace: namespace,
-				}, rg)
+				}, rgd)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(rg.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
-				g.Expect(rg.Status.TopologicalOrder).To(BeEmpty())
+				g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
+				g.Expect(rgd.Status.TopologicalOrder).To(BeEmpty())
 			}, 10*time.Second, time.Second).Should(Succeed())
 
-			Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+			Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 		})
 	})
 })

--- a/test/integration/suites/deploymentservice/suite_test.go
+++ b/test/integration/suites/deploymentservice/suite_test.go
@@ -71,41 +71,41 @@ var _ = Describe("DeploymentService", func() {
 		Expect(env.Client.Create(ctx, ns)).To(Succeed())
 
 		// Create ResourceGraphDefinition
-		rg, genInstance := deploymentService(namespace, "test-deployment-service")
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		rgd, genInstance := deploymentService(namespace, "test-deployment-service")
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is created and becomes ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify the ResourceGraphDefinition fields
-			g.Expect(createdRG.Spec.Schema.Kind).To(Equal("DeploymentService"))
-			g.Expect(createdRG.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
-			g.Expect(createdRG.Spec.Resources).To(HaveLen(2))
+			g.Expect(createdRGD.Spec.Schema.Kind).To(Equal("DeploymentService"))
+			g.Expect(createdRGD.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
+			g.Expect(createdRGD.Spec.Resources).To(HaveLen(2))
 
 			// Verify the ResourceGraphDefinition status
-			g.Expect(createdRG.Status.Conditions).To(HaveLen(3))
-			g.Expect(createdRG.Status.Conditions[0].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions).To(HaveLen(3))
+			g.Expect(createdRGD.Status.Conditions[0].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeReconcilerReady,
 			))
-			g.Expect(createdRG.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[1].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[1].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified,
 			))
-			g.Expect(createdRG.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[2].Type).To(
+			g.Expect(createdRGD.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Type).To(
 				Equal(krov1alpha1.ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced),
 			)
-			g.Expect(createdRG.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
-			g.Expect(createdRG.Status.TopologicalOrder).To(HaveLen(2))
-			g.Expect(createdRG.Status.TopologicalOrder).To(Equal([]string{"deployment", "service"}))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(2))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{"deployment", "service"}))
 		}, 10*time.Second, time.Second).Should(Succeed())
 
 		// Create instance
@@ -211,12 +211,12 @@ var _ = Describe("DeploymentService", func() {
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
 		// Delete ResourceGraphDefinition
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is deleted
 		Eventually(func() bool {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
 			}, &krov1alpha1.ResourceGraphDefinition{})
 			return errors.IsNotFound(err)

--- a/test/integration/suites/networkingstack/suite_test.go
+++ b/test/integration/suites/networkingstack/suite_test.go
@@ -70,47 +70,47 @@ var _ = Describe("NetworkingStack", func() {
 		Expect(env.Client.Create(ctx, ns)).To(Succeed())
 
 		// Create ResourceGraphDefinition
-		rg, genInstance := networkingStack("test-networking-stack", namespace)
-		Expect(env.Client.Create(ctx, rg)).To(Succeed())
+		rgd, genInstance := networkingStack("test-networking-stack", namespace)
+		Expect(env.Client.Create(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is created and becomes ready
-		createdRG := &krov1alpha1.ResourceGraphDefinition{}
+		createdRGD := &krov1alpha1.ResourceGraphDefinition{}
 		Eventually(func(g Gomega) {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
-			}, createdRG)
+			}, createdRGD)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify the ResourceGraphDefinition fields
-			g.Expect(createdRG.Spec.Schema.Kind).To(Equal("NetworkingStack"))
-			g.Expect(createdRG.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
-			g.Expect(createdRG.Spec.Resources).To(HaveLen(5)) // vpc, 3 subnets, security group
+			g.Expect(createdRGD.Spec.Schema.Kind).To(Equal("NetworkingStack"))
+			g.Expect(createdRGD.Spec.Schema.APIVersion).To(Equal("v1alpha1"))
+			g.Expect(createdRGD.Spec.Resources).To(HaveLen(5)) // vpc, 3 subnets, security group
 
 			// Verify the ResourceGraphDefinition status
-			g.Expect(createdRG.Status.TopologicalOrder).To(HaveLen(5))
-			g.Expect(createdRG.Status.TopologicalOrder).To(Equal([]string{
+			g.Expect(createdRGD.Status.TopologicalOrder).To(HaveLen(5))
+			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"vpc",
 				"securityGroup",
 				"subnetAZA",
 				"subnetAZB",
 				"subnetAZC",
 			}))
-			g.Expect(createdRG.Status.Conditions).To(HaveLen(3))
-			g.Expect(createdRG.Status.Conditions[0].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions).To(HaveLen(3))
+			g.Expect(createdRGD.Status.Conditions[0].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeReconcilerReady,
 			))
-			g.Expect(createdRG.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[1].Type).To(Equal(
+			g.Expect(createdRGD.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[1].Type).To(Equal(
 				krov1alpha1.ResourceGraphDefinitionConditionTypeGraphVerified,
 			))
-			g.Expect(createdRG.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(createdRG.Status.Conditions[2].Type).To(
+			g.Expect(createdRGD.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Type).To(
 				Equal(krov1alpha1.ResourceGraphDefinitionConditionTypeCustomResourceDefinitionSynced),
 			)
-			g.Expect(createdRG.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(createdRGD.Status.Conditions[2].Status).To(Equal(metav1.ConditionTrue))
 
-			g.Expect(createdRG.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
+			g.Expect(createdRGD.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateActive))
 		}, 10*time.Second, time.Second).Should(Succeed())
 
 		// Create instance
@@ -263,12 +263,12 @@ var _ = Describe("NetworkingStack", func() {
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
 		// Delete ResourceGraphDefinition
-		Expect(env.Client.Delete(ctx, rg)).To(Succeed())
+		Expect(env.Client.Delete(ctx, rgd)).To(Succeed())
 
 		// Verify ResourceGraphDefinition is deleted
 		Eventually(func() bool {
 			err := env.Client.Get(ctx, types.NamespacedName{
-				Name:      rg.Name,
+				Name:      rgd.Name,
 				Namespace: namespace,
 			}, &krov1alpha1.ResourceGraphDefinition{})
 			return errors.IsNotFound(err)


### PR DESCRIPTION
Following the previous documentation rename, this commit updates remaining code
references from `ResourceGroup` to `ResourceGraphDefinition`.