### PR TITLE
Tweak topological sort to preserve client-specified order

### DIFF
--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -509,7 +509,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 				assert.Contains(t, clusterDeps, "subnet2")
 
 				// Validate topological order
-				assert.Equal(t, []string{"clusterpolicy", "clusterrole", "vpc", "subnet1", "subnet2", "cluster"}, g.TopologicalOrder)
+				assert.Equal(t, []string{"vpc", "clusterpolicy", "clusterrole", "subnet1", "subnet2", "cluster"}, g.TopologicalOrder)
 			},
 		},
 		{
@@ -571,7 +571,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 				}, nil, nil),
 			},
 			wantErr: true,
-			errMsg:  "This would create a cycle",
+			errMsg:  "graph contains a cycle",
 		},
 		{
 			name: "independent pods",
@@ -726,7 +726,7 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 				}, nil, nil),
 			},
 			wantErr: true,
-			errMsg:  "This would create a cycle",
+			errMsg:  "graph contains a cycle",
 		},
 		{
 			name: "shared infrastructure dependencies",
@@ -919,17 +919,17 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 
 				// Validate topological order
 				assert.Equal(t, []string{
-					"policy",
-					"role",
 					"vpc",
 					"subnet1",
 					"subnet2",
 					"subnet3",
+					"secgroup",
+					"policy",
+					"role",
 					"cluster1",
 					"cluster2",
 					"cluster3",
 					"monitor",
-					"secgroup",
 				}, g.TopologicalOrder)
 			},
 		},

--- a/pkg/graph/dag/dag_test.go
+++ b/pkg/graph/dag/dag_test.go
@@ -14,18 +14,20 @@
 package dag
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestDAGAddNode(t *testing.T) {
 	d := NewDirectedAcyclicGraph()
 
-	if err := d.AddVertex("A"); err != nil {
+	if err := d.AddVertex("A", 1); err != nil {
 		t.Errorf("Failed to add node: %v", err)
 	}
 
-	if err := d.AddVertex("A"); err == nil {
+	if err := d.AddVertex("A", 1); err == nil {
 		t.Error("Expected error when adding duplicate node, but got nil")
 	}
 
@@ -36,117 +38,153 @@ func TestDAGAddNode(t *testing.T) {
 
 func TestDAGAddEdge(t *testing.T) {
 	d := NewDirectedAcyclicGraph()
-	d.AddVertex("A")
-	d.AddVertex("B")
+	if err := d.AddVertex("A", 1); err != nil {
+		t.Fatalf("error from AddVertex(A, 1): %v", err)
+	}
+	if err := d.AddVertex("B", 2); err != nil {
+		t.Fatalf("error from AddVertex(B, 2): %v", err)
+	}
 
-	if err := d.AddEdge("A", "B"); err != nil {
+	if err := d.AddDependencies("A", []string{"B"}); err != nil {
 		t.Errorf("Failed to add edge: %v", err)
 	}
 
-	if err := d.AddEdge("A", "C"); err == nil {
+	if err := d.AddDependencies("A", []string{"C"}); err == nil {
 		t.Error("Expected error when adding edge to non-existent node, but got nil")
 	}
 
-	if err := d.AddEdge("A", "A"); err == nil {
-		t.Error("Expected error when adding self refernce, but got nil")
+	if err := d.AddDependencies("A", []string{"A"}); err == nil {
+		t.Error("Expected error when adding self reference, but got nil")
 	}
 }
 
 func TestDAGHasCycle(t *testing.T) {
 	d := NewDirectedAcyclicGraph()
-	d.AddVertex("A")
-	d.AddVertex("B")
-	d.AddVertex("C")
+	if err := d.AddVertex("A", 1); err != nil {
+		t.Fatalf("error from AddVertex(A, 1): %v", err)
+	}
+	if err := d.AddVertex("B", 2); err != nil {
+		t.Fatalf("error from AddVertex(B, 2): %v", err)
+	}
+	if err := d.AddVertex("C", 3); err != nil {
+		t.Fatalf("error from AddVertex(C, 3): %v", err)
+	}
 
-	d.AddEdge("A", "B")
-	d.AddEdge("B", "C")
+	if err := d.AddDependencies("A", []string{"B"}); err != nil {
+		t.Fatalf("adding dependencies: %v", err)
+	}
+	if err := d.AddDependencies("B", []string{"C"}); err != nil {
+		t.Fatalf("adding dependencies: %v", err)
+	}
 
-	if cyclic, _ := d.HasCycle(); cyclic {
+	if cyclic, _ := d.hasCycle(); cyclic {
 		t.Error("DAG incorrectly reported a cycle")
 	}
 
-	if err := d.AddEdge("C", "A"); err == nil {
+	if err := d.AddDependencies("C", []string{"A"}); err == nil {
 		t.Error("Expected error when creating a cycle, but got nil")
 	}
 
 	// pointless to test for the cycle here, so we need to emulate one
 	// by artificially adding a cycle.
-	d.Vertices["C"].Edges["A"] = struct{}{}
-	if cyclic, _ := d.HasCycle(); !cyclic {
+	d.Vertices["C"].DependsOn["A"] = struct{}{}
+	if cyclic, _ := d.hasCycle(); !cyclic {
 		t.Error("DAG failed to detect cycle")
+	}
+
+	if _, err := d.TopologicalSort(); err == nil {
+		t.Errorf("TopologicalSort failed to detect cycle")
+	} else if AsCycleError(err) == nil {
+		t.Errorf("TopologicalSort returned unexpected error: %T %v", err, err)
 	}
 }
 
 func TestDAGTopologicalSort(t *testing.T) {
-	d := NewDirectedAcyclicGraph()
-	d.AddVertex("A")
-	d.AddVertex("B")
-	d.AddVertex("C")
-	d.AddVertex("D")
-	d.AddVertex("E")
-	d.AddVertex("F")
-
-	d.AddEdge("A", "B")
-	d.AddEdge("A", "C")
-	d.AddEdge("B", "D")
-	d.AddEdge("C", "D")
-	d.AddEdge("E", "A")
-	d.AddEdge("E", "F")
-	// [D B C A F E]
-
-	order, err := d.TopologicalSort()
-	if err != nil {
-		t.Errorf("topological sort failed: %v", err)
+	grid := []struct {
+		Nodes string
+		Edges string
+		Want  string
+	}{
+		{Nodes: "A,B", Want: "A,B"},
+		{Nodes: "A,B", Edges: "A->B", Want: "A,B"},
+		{Nodes: "A,B", Edges: "B->A", Want: "B,A"},
+		{Nodes: "A,B,C,D,E,F", Want: "A,B,C,D,E,F"},
+		{Nodes: "A,B,C,D,E,F", Edges: "C->D", Want: "A,B,C,D,E,F"},
+		{Nodes: "A,B,C,D,E,F", Edges: "D->C", Want: "A,B,D,E,F,C"},
+		{Nodes: "A,B,C,D,E,F", Edges: "F->A,F->B,B->A", Want: "C,D,E,F,B,A"},
+		{Nodes: "A,B,C,D,E,F", Edges: "B->A,C->A,D->B,D->C,F->E,A->E", Want: "D,F,B,C,A,E"},
 	}
 
-	// slices.Reverse(order)
+	for i, g := range grid {
+		t.Run(fmt.Sprintf("[%d] nodes=%s,edges=%s", i, g.Nodes, g.Edges), func(t *testing.T) {
+			d := NewDirectedAcyclicGraph()
+			for i, node := range strings.Split(g.Nodes, ",") {
+				if err := d.AddVertex(node, i); err != nil {
+					t.Fatalf("adding vertex: %v", err)
+				}
+			}
 
-	if !isValidTopologicalOrder(d, order) {
-		t.Errorf("invalid topological order: %v", order)
-	}
-}
+			if g.Edges != "" {
+				for _, edge := range strings.Split(g.Edges, ",") {
+					tokens := strings.SplitN(edge, "->", 2)
+					if err := d.AddDependencies(tokens[1], []string{tokens[0]}); err != nil {
+						t.Fatalf("adding edge %q: %v", edge, err)
+					}
+				}
+			}
 
-func TestDAGGetNodes(t *testing.T) {
-	d := NewDirectedAcyclicGraph()
-	d.AddVertex("A")
-	d.AddVertex("B")
-	d.AddVertex("C")
+			order, err := d.TopologicalSort()
+			if err != nil {
+				t.Errorf("topological sort failed: %v", err)
+			}
 
-	nodes := d.GetVertices()
-	expected := []string{"A", "B", "C"}
+			got := strings.Join(order, ",")
+			want := g.Want
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected result from TopologicalSort for nodes=%q edges=%q, got %q, want %q", g.Nodes, g.Edges, got, want)
+			}
 
-	if !reflect.DeepEqual(nodes, expected) {
-		t.Errorf("GetNodes() = %v, want %v", nodes, expected)
-	}
-}
-
-func TestDAGGetEdges(t *testing.T) {
-	d := NewDirectedAcyclicGraph()
-	d.AddVertex("A")
-	d.AddVertex("B")
-	d.AddVertex("C")
-	d.AddEdge("A", "B")
-	d.AddEdge("B", "C")
-
-	edges := d.GetEdges()
-	expected := [][2]string{{"A", "B"}, {"B", "C"}}
-
-	if !reflect.DeepEqual(edges, expected) {
-		t.Errorf("GetEdges() = %v, want %v", edges, expected)
+			checkValidTopologicalOrder(t, d, order)
+		})
 	}
 }
 
-func isValidTopologicalOrder(d *DirectedAcyclicGraph, order []string) bool {
+func checkValidTopologicalOrder(t *testing.T, d *DirectedAcyclicGraph, order []string) {
 	pos := make(map[string]int)
 	for i, node := range order {
 		pos[node] = i
 	}
+
+	// Verify that we obey the dependencies
 	for _, node := range order {
-		for successor := range d.Vertices[node].Edges {
+		for successor := range d.Vertices[node].DependsOn {
 			if pos[node] < pos[successor] {
-				return false
+				t.Errorf("invalid topological order: %v", order)
 			}
 		}
 	}
-	return true
+
+	// Verify that we also obey the ordering, unless we cannot
+	for i, nodeKey := range order {
+		if i == 0 {
+			continue
+		}
+		node := d.Vertices[nodeKey]
+		previousNode := d.Vertices[order[i-1]]
+		if previousNode.Order <= node.Order {
+			continue // these two nodes are in order
+		}
+
+		// These two nodes are out of order, there should be a dependency on one of the previous nodes
+		hasDep := false
+		for j := 0; j < i; j++ {
+			if _, found := node.DependsOn[order[j]]; found {
+				hasDep = true
+				break
+			}
+		}
+		if !hasDep {
+			t.Errorf("invalid topological order %q; node %v appears before %v", order, previousNode, node)
+		}
+	}
 }

--- a/pkg/graph/resource.go
+++ b/pkg/graph/resource.go
@@ -70,6 +70,9 @@ type Resource struct {
 	// This is useful when initiating the dynamic client to interact with the
 	// resource.
 	namespaced bool
+	// order reflects the original order in which the resources were specified,
+	// and lets us keep the client-specified ordering where the dependencies allow.
+	order int
 }
 
 // GetDependencies returns the dependencies of the resource.
@@ -104,6 +107,11 @@ func (r *Resource) addDependencies(deps ...string) {
 // GetID returns the ID of the resource.
 func (r *Resource) GetID() string {
 	return r.id
+}
+
+// GetOrder returns the original Order of the resource.
+func (r *Resource) GetOrder() int {
+	return r.order
 }
 
 // GetGroupVersionKind returns the GVK of the resource.
@@ -160,6 +168,7 @@ func (r *Resource) IsNamespaced() bool {
 func (r *Resource) DeepCopy() *Resource {
 	return &Resource{
 		id:                     r.id,
+		order:                  r.order,
 		gvr:                    r.gvr,
 		schema:                 r.schema,
 		originalObject:         r.originalObject.DeepCopy(),

--- a/test/integration/suites/ackekscluster/generator.go
+++ b/test/integration/suites/ackekscluster/generator.go
@@ -43,8 +43,8 @@ func eksCluster(
 				"clusterARN": "${cluster.status.ackResourceMetadata.arn}",
 			},
 		),
+		generator.WithResource("clusterRole", clusterRoleDef(namespace), nil, nil),
 		generator.WithResource("clusterVPC", vpcDef(namespace), nil, nil),
-		generator.WithResource("clusterElasticIPAddress", eipDef(namespace), nil, nil),
 		generator.WithResource("clusterInternetGateway", igwDef(namespace), nil, nil),
 		generator.WithResource("clusterRouteTable", routeTableDef(namespace), nil, nil),
 		generator.WithResource(
@@ -55,11 +55,11 @@ func eksCluster(
 			"clusterSubnetB",
 			subnetDef(namespace, "kro-cluster-public-subnet2", "us-west-2b", "192.168.64.0/18"), nil, nil,
 		),
-		generator.WithResource("clusterNATGateway", natGatewayDef(namespace), nil, nil),
-		generator.WithResource("clusterRole", clusterRoleDef(namespace), nil, nil),
-		generator.WithResource("clusterNodeRole", nodeRoleDef(namespace), nil, nil),
-		generator.WithResource("clusterAdminRole", adminRoleDef(namespace), nil, nil),
 		generator.WithResource("cluster", clusterDef(namespace), nil, nil),
+		generator.WithResource("clusterAdminRole", adminRoleDef(namespace), nil, nil),
+		generator.WithResource("clusterElasticIPAddress", eipDef(namespace), nil, nil),
+		generator.WithResource("clusterNATGateway", natGatewayDef(namespace), nil, nil),
+		generator.WithResource("clusterNodeRole", nodeRoleDef(namespace), nil, nil),
 		generator.WithResource("clusterNodeGroup", nodeGroupDef(namespace), nil, nil),
 	)
 

--- a/test/integration/suites/core/conditional_test.go
+++ b/test/integration/suites/core/conditional_test.go
@@ -213,8 +213,8 @@ var _ = Describe("Conditions", func() {
 			g.Expect(createdRGD.Status.TopologicalOrder).To(Equal([]string{
 				"deploymentA",
 				"serviceAccountA",
-				"deploymentB",
 				"serviceA",
+				"deploymentB",
 				"serviceAccountB",
 				"serviceB",
 			}))

--- a/test/integration/suites/core/topology_test.go
+++ b/test/integration/suites/core/topology_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Topology", func() {
 			}
 			g.Expect(graphCondition).ToNot(BeNil())
 			g.Expect(graphCondition.Status).To(Equal(metav1.ConditionFalse))
-			g.Expect(*graphCondition.Reason).To(ContainSubstring("This would create a cycle"))
+			g.Expect(*graphCondition.Reason).To(ContainSubstring("graph contains a cycle"))
 			g.Expect(rgd.Status.State).To(Equal(krov1alpha1.ResourceGraphDefinitionStateInactive))
 		}, 10*time.Second, time.Second).Should(Succeed())
 	})

--- a/test/integration/suites/networkingstack/generator.go
+++ b/test/integration/suites/networkingstack/generator.go
@@ -44,10 +44,10 @@ func networkingStack(
 			},
 		),
 		generator.WithResource("vpc", vpcDef(), nil, nil),
+		generator.WithResource("securityGroup", securityGroupDef(), nil, nil),
 		generator.WithResource("subnetAZA", subnetDef("a", "us-west-2a", "192.168.0.0/18"), nil, nil),
 		generator.WithResource("subnetAZB", subnetDef("b", "us-west-2b", "192.168.64.0/18"), nil, nil),
 		generator.WithResource("subnetAZC", subnetDef("c", "us-west-2c", "192.168.128.0/18"), nil, nil),
-		generator.WithResource("securityGroup", securityGroupDef(), nil, nil),
 	)
 
 	instanceGenerator := func(namespace, name string) *unstructured.Unstructured {


### PR DESCRIPTION
If there are no explicit dependencies between two nodes,
try to keep them in the same order.

By doing this, we can minimize the need for synthetic dependencies.
