### PR TITLE
Infer `object` type from `OneOf` structural constraints `required/not patterns`

### DIFF
--- a/pkg/graph/parser/parser.go
+++ b/pkg/graph/parser/parser.go
@@ -82,10 +82,23 @@ func getExpectedTypes(schema *spec.Schema) ([]string, error) {
 	// Handle OneOf schemas
 	if len(schema.OneOf) > 0 {
 		var types []string
-		for _, subType := range schema.OneOf {
-			types = append(types, subType.Type...)
+
+		for _, subSchema := range schema.OneOf {
+			// If there are structural constraints, inject object
+			if len(subSchema.Required) > 0 || subSchema.Not != nil {
+				if !slices.Contains(types, "object") {
+					types = append(types, "object")
+				}
+			}
+			// Collect types if present
+			if len(subSchema.Type) > 0 {
+				types = append(types, subSchema.Type...)
+			}
 		}
-		return types, nil
+		// If we found any types, return them
+		if len(types) > 0 {
+			return types, nil
+		}
 	}
 
 	// Handle AnyOf schemas


### PR DESCRIPTION
This change improves type resolution 
for complex schemas that use OneOf with required/not patterns while also 
maintaining explicit type information.

`Key changes`:
- Detects and combines structural constraints with explicit types
- Ensures object type is included when required/not patterns are present
- Maintains backward compatibility for existing OneOf schemas

`Key insight`: Structural constraints like `required` and `not` can only be applied to 
objects since they operate on field presence/absence. Therefore, any schema using these 
constraints must be treated as an object type, even if not explicitly declared.