### PR TITLE
docs: fix RGD abbreviations in docs

### DIFF
--- a/examples/aws/eks-cluster-mgmt/clusters/rg/vpc.yaml
+++ b/examples/aws/eks-cluster-mgmt/clusters/rg/vpc.yaml
@@ -24,7 +24,7 @@ spec:
       publicSubnet2ID: ${publicSubnet2.status.subnetID}
       privateSubnet1ID: ${privateSubnet1.status.subnetID}
       privateSubnet2ID: ${privateSubnet2.status.subnetID}
-  resources: # how to publish a field in the RG claim e.g. vpcID
+  resources: # how to publish a field in the RGD claim e.g. vpcID
   - id: vpc
     template:
       apiVersion: ec2.services.k8s.aws/v1alpha1

--- a/examples/aws/webstack/Readme.md
+++ b/examples/aws/webstack/Readme.md
@@ -3,15 +3,17 @@
 This example creates a ResourceGraphDefinition called `WebStack` comprised of
 three other RGs: `WebApp`, `S3Bucket`, and `PodIdentity`
 
-![Netsted RG Instance](../../images/architecture-diagrams/kro-WebStack.png)
-_Fugure 1: Nested RG Example_
+![Netsted RGD Instance](../../images/architecture-diagrams/kro-WebStack.png)
+_Fugure 1: Nested RGD Example_
 
 ### Create ResourceGraphDefinitions
 
 Change directory to `examples`:
+
 ```
 cd examples/
 ```
+
 Apply the RGs to your cluster:
 
 ```
@@ -22,7 +24,7 @@ kubectl apply -f webstack/rg.yaml
 Validate the RGs statuses are Active:
 
 ```
-kubectl get rg
+kubectl get rgd
 ```
 
 Expected result:
@@ -36,24 +38,33 @@ webstack.kro.run      v1alpha1     WebStack      Active    7m
 ```
 
 ### Create an Instance of kind WebStack
+
 Create an environment variable with uniquie name, that will be the name of your S3 Bucket.
+
 ```
 export RESOURCES_NAME=<test-app-11223344-replace-me-with-random-string>
 ```
+
 Validate the variable populated:
+
 ```
 echo $RESOURCES_NAME
 ```
+
 Expected result:
+
 ```
 <test-app-11223344-my-random-string>
 ```
+
 Run the following command to replace the `$RESOURCES_NAME` variable in `instance-tmpl.yaml` file and create
-a new file called instance.yaml. 
+a new file called instance.yaml.
+
 ```shell
 envsubst < "webstack/instance-tmpl.yaml" > "webstack/instance.yaml"
 ```
-Apply the `webstack/instance.yaml` 
+
+Apply the `webstack/instance.yaml`
 
 ```
 kubectl apply -f webstack/instance.yaml
@@ -96,10 +107,13 @@ Expected result:
 ```
 
 ### Troubleshoot
+
 If you get the folling error:
+
 ```
 Error connecting to S3:...
 ```
+
 Try restarting the pod.
 
 ### Clean up

--- a/examples/kubernetes/webapp/Readme.md
+++ b/examples/kubernetes/webapp/Readme.md
@@ -5,13 +5,13 @@ the default nginx container image.
 
 ### Create ResourceGraphDefinition called WebApp
 
-Apply the RG to your cluster:
+Apply the RGD to your cluster:
 
 ```
 kubectl apply -f rg.yaml
 ```
 
-Validate the RG status is Active:
+Validate the RGD status is Active:
 
 ```
 kubectl get rgd webapp.kro.run

--- a/test/README.md
+++ b/test/README.md
@@ -48,14 +48,14 @@ controllers, you should:
 2. Trigger ResourceGraphDefinition reconciliation
 3. Check that the ResourceGraphDefinition status was updated correctly
 4. Verify that the correct Create (CRD) call was made to the API server
-5. Check that the controller is watching the correct RG instances
+5. Check that the controller is watching the correct RGD instances
 6. Create a ResourceGraphDefinition instance
 7. Trigger the ResourceGraphDefinition instance reconciliation
 8. Check that the ResourceGraphDefinition instance status was updated correctly
 9. Verify that the some resources were created in the cluster
 10. Trigger a second reconciliation and check that the status was updated
     correctly
-11. Repeat until all the RG instances are created
+11. Repeat until all the RGD instances are created
 12. Do the same for updates and deletions
 
 ## E2e tests

--- a/website/docs/docs/getting-started/02-deploy-a-resource-graph-definition.md
+++ b/website/docs/docs/getting-started/02-deploy-a-resource-graph-definition.md
@@ -44,7 +44,7 @@ metadata:
   name: my-application
 spec:
   # kro uses this simple schema to create your CRD schema and apply it
-  # The schema defines what users can provide when they instantiate the RG (create an instance).
+  # The schema defines what users can provide when they instantiate the RGD (create an instance).
   schema:
     apiVersion: v1alpha1
     kind: Application
@@ -140,7 +140,7 @@ spec:
    the ResourceGraphDefinition using the `kubectl` command:
 
    ```bash
-   kubectl get rg my-application -owide
+   kubectl get rgd my-application -owide
    ```
 
    You should see the ResourceGraphDefinition in the `Active` state, along with relevant

--- a/website/docs/docs/overview.md
+++ b/website/docs/docs/overview.md
@@ -4,16 +4,16 @@ sidebar_position: 1
 
 # What is kro?
 
-**kro** (Kube Resource Orchestrator) is an open-source, Kubernetes-native project 
-that allows you to define custom **Kubernetes APIs** using simple and straightforward 
-configuration. With kro, you can easily configure new custom APIs that create a 
-group of Kubernetes objects and the logical operations between them. kro leverages 
-[CEL (Common Expression Language)](https://github.com/google/cel-spec), the same 
+**kro** (Kube Resource Orchestrator) is an open-source, Kubernetes-native project
+that allows you to define custom **Kubernetes APIs** using simple and straightforward
+configuration. With kro, you can easily configure new custom APIs that create a
+group of Kubernetes objects and the logical operations between them. kro leverages
+[CEL (Common Expression Language)](https://github.com/google/cel-spec), the same
 language used by Kubernetes webhooks, for logical operations. Using CEL expressions,
 you can easily pass values from one object to another and incorporate conditionals into
-your custom API definitions. Based on the CEL expressions, kro automatically calculates 
-the order in which objects should be created. You can define default values for fields 
-in the API specification, streamlining the process for end users who can then 
+your custom API definitions. Based on the CEL expressions, kro automatically calculates
+the order in which objects should be created. You can define default values for fields
+in the API specification, streamlining the process for end users who can then
 effortlessly invoke these custom APIs to create grouped resources.
 
 # How does kro work?
@@ -49,7 +49,7 @@ Custom Resources for the ResourceGraphDefinition CRD.
 In the depicted example, the **Platform Team** has created a **RG** with
 arbitrary name "Application Stack" that encapsulates the necessary resources,
 along with any additional logic, abstractions, and security best practices. When
-the RG is applied to the cluster, a new API of kind ApplicationStack is created
+the RGD is applied to the cluster, a new API of kind ApplicationStack is created
 and available for Developer to interact with. The Developers no longer need to
 directly manage the underlying infrastructure complexities, as the custom API
 handles the deployment and configuration of the required resources.

--- a/website/docs/examples/web-app-ingress.md
+++ b/website/docs/examples/web-app-ingress.md
@@ -11,7 +11,7 @@ metadata:
   name: my-application
 spec:
   # kro uses this simple schema to create your CRD schema and apply it
-  # The schema defines what users can provide when they instantiate the RG (create an instance).
+  # The schema defines what users can provide when they instantiate the RGD (create an instance).
   schema:
     apiVersion: v1alpha1
     kind: Application


### PR DESCRIPTION
Update documentation to consistently use "RGD" (Resource Graph Definition) instead of "RG"