### PR TITLE
Copy finalizers from observed to desired object on resource update

### DIFF
--- a/pkg/controller/instance/controller_reconcile.go
+++ b/pkg/controller/instance/controller_reconcile.go
@@ -270,7 +270,9 @@ func (igr *instanceGraphReconciler) updateResource(
 	igr.instanceSubResourcesLabeler.ApplyLabels(desired)
 
 	// Apply changes to the resource
+	// TODO: Handle annotations
 	desired.SetResourceVersion(observed.GetResourceVersion())
+	desired.SetFinalizers(observed.GetFinalizers())
 	_, err = rc.Update(ctx, desired, metav1.UpdateOptions{})
 	if err != nil {
 		resourceState.State = "ERROR"


### PR DESCRIPTION
Testing the changes in https://github.com/kro-run/kro/pull/173 - even though resource updates do seem to work, the finalizers are removed from the updated resource.
This will add finalizers, if any are defined.