### PR TITLE
add 'schema' to kro reserved keywords list

### DIFF
--- a/pkg/graph/validation.go
+++ b/pkg/graph/validation.go
@@ -54,6 +54,7 @@ var (
 		"resources",
 		"runtime",
 		"serviceAccountName",
+		"schema",
 		"spec",
 		"status",
 		"kro",


### PR DESCRIPTION
'schema' is reserved as it's used to reference instance fields (e.g `schema.spec.name` || `schema.metadata.name`)