### PR TITLE
ci: add github release workflow

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,0 +1,20 @@
+name: Create Github Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Add GitHub Action workflow to automatically create releases when a new version tag is pushed.