### PR TITLE
Fix examples with old schema

### DIFF
--- a/examples/aws/serverless-microservice/README.md
+++ b/examples/aws/serverless-microservice/README.md
@@ -202,6 +202,7 @@ kubectl describe resourcegraphdefinition.kro.run/microservice.kro.run
 
 Expected result (resource definitions removed for brevity)
 
+<!-- TODO: update this example output to the latest schema -->
 ```
 Name:         microservice.kro.run
 Namespace:    default

--- a/website/docs/examples/aws/pod-rds-dbinstance.md
+++ b/website/docs/examples/aws/pod-rds-dbinstance.md
@@ -10,11 +10,10 @@ kind: ResourceGraphDefinition
 metadata:
   name: deploymentandawspostgres
 spec:
-  apiVersion: v1alpha1
-  kind: DeploymentAndAWSPostgres
-
   # CRD Definition
-  definition:
+  schema:
+    apiVersion: v1alpha1
+    kind: DeploymentAndAWSPostgres
     spec:
       applicationName: string
       image: string
@@ -23,7 +22,7 @@ spec:
   # Resources
   resources:
     - id: dbinstance
-      definition:
+      template:
         apiVersion: rds.services.k8s.aws/v1alpha1
         kind: DBInstance
         metadata:
@@ -36,7 +35,7 @@ spec:
           dbInstanceClass: db.t3.micro
 
     - id: pod
-      definition:
+      template:
         apiVersion: v1
         kind: Pod
         metadata:

--- a/website/docs/examples/basic/noop.md
+++ b/website/docs/examples/basic/noop.md
@@ -8,11 +8,11 @@ sidebar_position: 101
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
-  name: kro.run/v1alpha1
+  name: noop
 spec:
-  apiVersion: v1alpha1
-  kind: NoOp
-  definition:
+  schema:
+    apiVersion: v1alpha1
+    kind: NoOp
     spec:
       name: string | required=true
   resources: []

--- a/website/docs/examples/basic/web-app.md
+++ b/website/docs/examples/basic/web-app.md
@@ -10,14 +10,14 @@ kind: ResourceGraphDefinition
 metadata:
   name: deploymentservice
 spec:
-  apiVersion: v1alpha1
-  kind: DeploymentService
-  definition:
+  schema:
+    apiVersion: v1alpha1
+    kind: DeploymentService
     spec:
       name: string
   resources:
     - id: deployment
-      definition:
+      template:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
@@ -38,7 +38,7 @@ spec:
                   ports:
                     - containerPort: 80
     - id: service
-      definition:
+      template:
         apiVersion: v1
         kind: Service
         metadata:


### PR DESCRIPTION
The basic examples and a few others don't work anymore. The schema must have moved on from when this project started. Brought them back up to current schema.

