### PR TITLE
Add helm support for existing controller flags

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,6 +57,18 @@ spec:
               value: {{ .Values.config.dynamicControllerConcurrentReconciles | quote }}
             - name: KRO_LOG_LEVEL
               value: {{ .Values.config.logLevel | quote }}
+            - name: KRO_DYNAMIC_CONTROLLER_DEFAULT_RESYNC_PERIOD
+              value: {{ .Values.config.dynamicControllerDefaultResyncPeriod | quote }}
+            - name: KRO_DYNAMIC_CONTROLLER_DEFAULT_QUEUE_MAX_RETRIES
+              value: {{ .Values.config.dynamicControllerDefaultQueueMaxRetries | quote }}
+            - name: KRO_DYNAMIC_CONTROLLER_DEFAULT_SHUTDOWN_TIMEOUT
+              value: {{ .Values.config.dynamicControllerDefaultShutdownTimeout | quote }}
+            - name: KRO_CLIENT_QPS
+              value: {{ .Values.config.clientQps | quote }}
+            - name: KRO_CLIENT_BURST
+              value: {{ .Values.config.clientBurst | quote }}
+            - name: KRO_LEADER_ELECTION
+              value: {{ .Values.config.enableLeaderElection | quote }}
           args:
             - --allow-crd-deletion
             - "$(KRO_ALLOW_CRD_DELETION)"
@@ -70,6 +82,18 @@ spec:
             - "$(KRO_DYNAMIC_CONTROLLER_CONCURRENT_RECONCILES)"
             - --log-level
             - "$(KRO_LOG_LEVEL)"
+            - --dynamic-controller-default-resync-period
+            - "$(KRO_DYNAMIC_CONTROLLER_DEFAULT_RESYNC_PERIOD)"
+            - --dynamic-controller-default-queue-max-retries
+            - "$(KRO_DYNAMIC_CONTROLLER_DEFAULT_QUEUE_MAX_RETRIES)"
+            - --dynamic-controller-default-shutdown-timeout
+            - "$(KRO_DYNAMIC_CONTROLLER_DEFAULT_SHUTDOWN_TIMEOUT)"
+            - --client-qps
+            - "$(KRO_CLIENT_QPS)"
+            - --client-burst
+            - "$(KRO_CLIENT_BURST)"
+            - --leader-elect
+            - "$(KRO_LEADER_ELECTION)"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -84,6 +84,12 @@ deployment:
 config:
   # Allow kro to delete CRDs
   allowCRDDeletion: false
+  # The maximum number of queries per second to allow
+  clientQps: 100
+  # The number of requests that can be stored for processing before the server starts enforcing the QPS limit
+  clientBurst: 150
+  # Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
+  enableLeaderElection: false
   # The address the metric endpoint binds to
   metricsBindAddress: :8078
   # The address the probe endpoint binds to
@@ -92,6 +98,12 @@ config:
   resourceGraphDefinitionConcurrentReconciles: 1
   # The number of dynamic controller reconciles to run in parallel
   dynamicControllerConcurrentReconciles: 1
+  # The interval at which the controller will re list resources even with no changes, in hours
+  dynamicControllerDefaultResyncPeriod: 10
+  # The maximum number of retries for an item in the queue will be retried before being dropped
+  dynamicControllerDefaultQueueMaxRetries: 20
+  # The maximum duration to wait for the controller to gracefully shutdown, in seconds
+  dynamicControllerDefaultShutdownTimeout: 60
   # The log level verbosity. 0 is the least verbose, 5 is the most verbose
   logLevel: 3
 


### PR DESCRIPTION
The current helm chart values file is missing multiple controller argument flags. This merge requests adds the missing flags as options in the chart.