### PR TITLE
Implement KRO Labels For RGD CRDs

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -43,16 +43,19 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(ctx
 		return nil, nil, err
 	}
 
-	// Ensure CRD exists and is up to date
-	log.V(1).Info("reconciling resource graph definition CRD")
-	if err := r.reconcileResourceGraphDefinitionCRD(ctx, processedRGD.Instance.GetCRD()); err != nil {
-		return processedRGD.TopologicalOrder, resourcesInfo, err
-	}
-
 	// Setup metadata labeling
 	graphExecLabeler, err := r.setupLabeler(rgd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to setup labeler: %w", err)
+	}
+
+	crd := processedRGD.Instance.GetCRD()
+	graphExecLabeler.ApplyLabels(&crd.ObjectMeta)
+
+	// Ensure CRD exists and is up to date
+	log.V(1).Info("reconciling resource graph definition CRD")
+	if err := r.reconcileResourceGraphDefinitionCRD(ctx, crd); err != nil {
+		return processedRGD.TopologicalOrder, resourcesInfo, err
 	}
 
 	// Setup and start microcontroller

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -117,7 +117,6 @@ func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
 	return map[string]string{
 		ResourceGraphDefinitionIDLabel:        string(rgMeta.GetUID()),
 		ResourceGraphDefinitionNameLabel:      rgMeta.GetName(),
-		ResourceGraphDefinitionNamespaceLabel: rgMeta.GetNamespace(),
 	}
 }
 


### PR DESCRIPTION
In relation to issue #185, we should add KRO management labels to CRD's created via ResourceGraphDefinitions.

Example label output from `example/webapp/rg.yaml`
```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  creationTimestamp: "2025-02-08T04:53:40Z"
  generation: 1
  labels:
    kro.run/controller-pod-id: kro-pod
    kro.run/kro-version: 0.2.1
    kro.run/owned: "true"
    kro.run/resource-graph-definition-id: f25ffd07-df0c-4c7e-b90e-507c80d317fc
    kro.run/resource-graph-definition-name: webapp.kro.run
  name: webapps.kro.run
  resourceVersion: "33637"
  uid: 0e3fdd78-bafe-4bca-b44e-9cb6e23dce58
```

