### PR TITLE
fix: helm fix metrics port

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -35,7 +35,7 @@ deployment:
   # Number of replicas for the Pods to run
   replicaCount: 1
   # Port that the container will expose
-  containerPort: 8080
+  containerPort: 8078
   # Annotations to add to the Pod
   podAnnotations: {}
   # Labels to add to the Pod


### PR DESCRIPTION
The Kro application uses port 8078 for metrics (via the -metrics-bind-address parameter). Therefore, this port should be specified as metricsport in the deployment configuration. Otherwise, metrics cannot be properly fetched.

This PR fixes: [kro-run/kro#294](https://github.com/kro-run/kro/issues/294)