### PR TITLE
feat: allow escaped nested expressions

### DIFF
--- a/pkg/graph/parser/cel_test.go
+++ b/pkg/graph/parser/cel_test.go
@@ -115,6 +115,24 @@ func TestExtractExpressions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "Nested expression but with quotes",
+			input:   "${outer(\"${inner}\")}",
+			want:    []string{"outer(\"${inner}\")"},
+			wantErr: false,
+		},
+		{
+			name:    "Nested closing brace without opening one",
+			input:   "${\"text with }} inside\"}",
+			want:    []string{"\"text with }} inside\""},
+			wantErr: false,
+		},
+		{
+			name:    "Nested open brace without closing one",
+			input:   "${\"text with { inside\"}",
+			want:    []string{"\"text with { inside\""},
+			wantErr: false,
+		},
+		{
 			name:    "Expressions with dictionary building",
 			input:   "${true ? {'key': 'value'} : {'key': 'value2'}}",
 			want:    []string{"true ? {'key': 'value'} : {'key': 'value2'}"},
@@ -197,6 +215,9 @@ func TestIsOneShotExpression(t *testing.T) {
 		{"With newlines", "${resource.list.map(\n  x,\n  x * 2\n)}", true, false},
 		{"Complex expression", "${resource.list.map(x, x.field).filter(y, y > 5)}", true, false},
 		{"Nested expression (should error)", "${outer(${inner})}", false, true},
+		{"Nested expression but with quotes", "${outer(\"${inner}\")}", true, false},
+		{"Nested closing brace without opening one", "${\"text with }} inside\"}", true, false},
+		{"Nested open brace without closing one", "${\"text with { inside\"}", true, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR is Related to #291

This commit enhances the expression parser to properly handle nested expressions when they appear inside string literals, adding string literal tracking and escape sequence handling while still rejecting unquoted nested expressions.