### PR TITLE
Handle Secrets that are transformed by server and hence show up as diff

### DIFF
--- a/pkg/controller/instance/delta/delta.go
+++ b/pkg/controller/instance/delta/delta.go
@@ -36,6 +36,7 @@ type Difference struct {
 // their differences. It performs a deep comparison while being aware of Kubernetes
 // metadata specifics. The comparison:
 //
+// - Applies type-specific transformations to match server-side representation
 // - Cleans metadata from both objects to avoid spurious differences
 // - Walks object trees in parallel to find actual value differences
 // - Builds path strings to precisely identify where differences occurs
@@ -44,6 +45,10 @@ func Compare(desired, observed *unstructured.Unstructured) ([]Difference, error)
 	desiredCopy := desired.DeepCopy()
 	observedCopy := observed.DeepCopy()
 
+	// Transform objects to match server-side representation
+	if err := TransformObjectToServerSideRepresentation(desiredCopy); err != nil {
+		return nil, fmt.Errorf("failed to transform desired object: %w", err)
+	}
 	cleanMetadata(desiredCopy)
 	cleanMetadata(observedCopy)
 

--- a/pkg/controller/instance/delta/transform.go
+++ b/pkg/controller/instance/delta/transform.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delta
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ObjectTransformer is an interface for transforming objects before comparison
+type ObjectTransformer interface {
+	// Transform modifies the object to match server-side representation
+	Transform(obj *unstructured.Unstructured) error
+	// CanTransform returns true if this transformer can handle the given object
+	CanTransform(obj *unstructured.Unstructured) bool
+}
+
+// transformerRegistry holds all registered transformers
+var transformerRegistry []ObjectTransformer
+
+// RegisterTransformer adds a new transformer to the registry
+func RegisterTransformer(t ObjectTransformer) {
+	transformerRegistry = append(transformerRegistry, t)
+}
+
+// TransformObjectToServerSideRepresentation applies all applicable transformers to the object
+func TransformObjectToServerSideRepresentation(obj *unstructured.Unstructured) error {
+	for _, transformer := range transformerRegistry {
+		if transformer.CanTransform(obj) {
+			if err := transformer.Transform(obj); err != nil {
+				return fmt.Errorf("failed to transform object: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// SecretTransformer handles transformation of Secret objects
+type SecretTransformer struct{}
+
+// CanTransform returns true if the object is a Secret
+func (t *SecretTransformer) CanTransform(obj *unstructured.Unstructured) bool {
+	return obj.GetAPIVersion() == "v1" && obj.GetKind() == "Secret"
+}
+
+// Transform modifies the Secret object to match server-side representation:
+// - Moves stringData to data with base64 encoding
+// - Merges any existing data with encoded stringData (stringData takes precedence)
+func (t *SecretTransformer) Transform(obj *unstructured.Unstructured) error {
+	// Get stringData if it exists
+	stringData, exists, err := unstructured.NestedMap(obj.Object, "stringData")
+	if err != nil {
+		return fmt.Errorf("failed to get stringData: %w", err)
+	}
+	if !exists || len(stringData) == 0 {
+		return nil
+	}
+
+	// Get existing data or create new map
+	data, exists, err := unstructured.NestedMap(obj.Object, "data")
+	if err != nil {
+		return fmt.Errorf("failed to get data: %w", err)
+	}
+	if !exists {
+		data = make(map[string]interface{})
+	}
+
+	// Encode stringData values and add to data
+	for k, v := range stringData {
+		strVal, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("stringData value for key %q is not a string", k)
+		}
+		encoded := base64.StdEncoding.EncodeToString([]byte(strVal))
+		data[k] = encoded
+	}
+
+	// Update data in the object
+	if err := unstructured.SetNestedMap(obj.Object, data, "data"); err != nil {
+		return fmt.Errorf("failed to set data: %w", err)
+	}
+
+	// Remove stringData
+	unstructured.RemoveNestedField(obj.Object, "stringData")
+	return nil
+}
+
+func init() {
+	// Register the Secret transformer
+	RegisterTransformer(&SecretTransformer{})
+}

--- a/pkg/controller/instance/delta/transform_test.go
+++ b/pkg/controller/instance/delta/transform_test.go
@@ -1,0 +1,206 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delta
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSecretTransformer_CanTransform(t *testing.T) {
+	transformer := &SecretTransformer{}
+
+	tests := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name: "secret object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "non-secret object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transformer.CanTransform(tt.obj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSecretTransformer_Transform(t *testing.T) {
+	transformer := &SecretTransformer{}
+
+	tests := []struct {
+		name        string
+		input       *unstructured.Unstructured
+		expected    *unstructured.Unstructured
+		expectError bool
+	}{
+		{
+			name: "stringData only",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"stringData": map[string]interface{}{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"data": map[string]interface{}{
+						"key1": base64.StdEncoding.EncodeToString([]byte("value1")),
+						"key2": base64.StdEncoding.EncodeToString([]byte("value2")),
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "stringData and data",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"data": map[string]interface{}{
+						"key1": base64.StdEncoding.EncodeToString([]byte("existing1")),
+						"key3": base64.StdEncoding.EncodeToString([]byte("value3")),
+					},
+					"stringData": map[string]interface{}{
+						"key1": "value1", // Should override existing key1
+						"key2": "value2", // New key
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"data": map[string]interface{}{
+						"key1": base64.StdEncoding.EncodeToString([]byte("value1")),
+						"key2": base64.StdEncoding.EncodeToString([]byte("value2")),
+						"key3": base64.StdEncoding.EncodeToString([]byte("value3")),
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "no stringData",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"data": map[string]interface{}{
+						"key1": base64.StdEncoding.EncodeToString([]byte("value1")),
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"data": map[string]interface{}{
+						"key1": base64.StdEncoding.EncodeToString([]byte("value1")),
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid stringData value",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"stringData": map[string]interface{}{
+						"key1": int64(123), // Not a string
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := transformer.Transform(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.Object, tt.input.Object)
+		})
+	}
+}
+
+func TestCompare_SecretTransformation(t *testing.T) {
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name": "test-secret",
+			},
+			"stringData": map[string]interface{}{
+				"username": "admin",
+				"password": "secret123",
+			},
+		},
+	}
+
+	observed := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name": "test-secret",
+			},
+			"data": map[string]interface{}{
+				"username": base64.StdEncoding.EncodeToString([]byte("admin")),
+				"password": base64.StdEncoding.EncodeToString([]byte("secret123")),
+			},
+		},
+	}
+
+	differences, err := Compare(desired, observed)
+	assert.NoError(t, err)
+	assert.Empty(t, differences, "Expected no differences after transformation")
+}


### PR DESCRIPTION
- Add code infra to handle secrets that are transformed by the server
- Add logic to allow future special case handling as generic object transformers
- Add unit tests

Fixes #272 

Using tests defined in https://github.com/kro-run/kro/pull/290

## Tests Run
```
❯ go test -v ./test/e2e/suites/advanced/...
=== RUN   TestSecretsInResources
    using_secrets_test.go:27: Using namespace: e2e-secrets-in-resources-1739398489, from: testdata/../../../../test/e2e/testdata/secrets-in-resources
    testcase.go:193: Running step0: Install RGD and verify that the RGD is active
    testcase.go:359:    Applying ResourceGraphDefinition/deployment-with-secret-rgd[rgd.yaml]
    verify.go:57:       Verifying ResourceGraphDefinition/deployment-with-secret-rgd[0rgd.yaml]
    verify.go:57:       Verifying CustomResourceDefinition/deploymentwithsecrets.kro.run[1instancecrd.yaml]
    testcase.go:193: Running step1: Create instance DeploymentWithSecret with replicas=2 and tokenID=sometokenid and tokenSecret=kq4gihvszzgn1p0r
    testcase.go:359:    Applying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    verify.go:57:       Verifying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Secret/test-instance-secret[secret.yaml]
    testcase.go:193: Running step2: Update instance DeploymentWithSecret with tokenID=newtokenid and tokenSecret=newtokensecret
    testcase.go:359:    Applying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    verify.go:57:       Verifying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Secret/test-instance-secret[secret.yaml]
    testcase.go:134: Deleting namespace: e2e-secrets-in-resources-1739398489
    testcase.go:148: Deleting cluster-scoped object: ResourceGraphDefinition/deployment-with-secret-rgd
--- PASS: TestSecretsInResources (40.19s)
PASS
ok      github.com/kro-run/kro/test/e2e/suites/advanced 40.258s
```