### PR TITLE
Allow referencing metadata.resourceVersion in the RGD resources

### DIFF
--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -44,7 +44,8 @@ func NewEmulator() *Emulator {
 }
 
 // GenerateDummyCR generates a dummy CR based on the provided schema.
-func (e *Emulator) GenerateDummyCR(gvk schema.GroupVersionKind, schema *spec.Schema) (*unstructured.Unstructured, error) {
+func (e *Emulator) GenerateDummyCR(gvk schema.GroupVersionKind,
+	schema *spec.Schema) (*unstructured.Unstructured, error) {
 	if schema == nil {
 		return nil, fmt.Errorf("schema is nil for %v", gvk)
 	}
@@ -70,6 +71,7 @@ func (e *Emulator) GenerateDummyCR(gvk schema.GroupVersionKind, schema *spec.Sch
 	cr.SetKind(gvk.Kind)
 	cr.SetName(fmt.Sprintf("%s-sample", strings.ToLower(gvk.Kind)))
 	cr.SetNamespace("default")
+	cr.SetResourceVersion(fmt.Sprintf("%d", e.rand.Intn(1000)))
 	return cr, nil
 }
 


### PR DESCRIPTION
Add resourceVersion in the dummy object so that referencing metadata.resourceVersion does not throw an error when validating the RGD.

fixes #300

## Tests ran
Using tests defined in https://github.com/kro-run/kro/pull/290

```
❯ go test -v ./test/e2e/suites/advanced/...
=== RUN   TestSecretsInResources
    using_secrets_test.go:27: Using namespace: e2e-secrets-in-resources-1739398489, from: testdata/../../../../test/e2e/testdata/secrets-in-resources
    testcase.go:193: Running step0: Install RGD and verify that the RGD is active
    testcase.go:359:    Applying ResourceGraphDefinition/deployment-with-secret-rgd[rgd.yaml]
    verify.go:57:       Verifying ResourceGraphDefinition/deployment-with-secret-rgd[0rgd.yaml]
    verify.go:57:       Verifying CustomResourceDefinition/deploymentwithsecrets.kro.run[1instancecrd.yaml]
    testcase.go:193: Running step1: Create instance DeploymentWithSecret with replicas=2 and tokenID=sometokenid and tokenSecret=kq4gihvszzgn1p0r
    testcase.go:359:    Applying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    verify.go:57:       Verifying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Secret/test-instance-secret[secret.yaml]
    testcase.go:193: Running step2: Update instance DeploymentWithSecret with tokenID=newtokenid and tokenSecret=newtokensecret
    testcase.go:359:    Applying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Deployment/test-instance[deployment.yaml]
    verify.go:57:       Verifying DeploymentWithSecret/test-instance[instance.yaml]
    verify.go:57:       Verifying Secret/test-instance-secret[secret.yaml]
    testcase.go:134: Deleting namespace: e2e-secrets-in-resources-1739398489
    testcase.go:148: Deleting cluster-scoped object: ResourceGraphDefinition/deployment-with-secret-rgd
--- PASS: TestSecretsInResources (40.19s)
PASS
ok      github.com/kro-run/kro/test/e2e/suites/advanced 40.258s

```