### PR TITLE
chore: update golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,5 +24,5 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=5m
-          version: v1.60
+          version: v1.64
           only-new-issues: true


### PR DESCRIPTION
Update golangci-lint to v1.64 to supoort go1.24