### PR TITLE
fix: ensure informers are cleaned up when ResourceGraphDefinitions are deleted

### DIFF
--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -71,7 +71,7 @@ func GetResourceGraphDefinitionInstanceGVK(group, apiVersion, kind string) schem
 func GetResourceGraphDefinitionInstanceGVR(group, apiVersion, kind string) schema.GroupVersionResource {
 	pluralKind := flect.Pluralize(strings.ToLower(kind))
 	return schema.GroupVersionResource{
-		Group:    fmt.Sprintf("%s.%s", pluralKind, group),
+		Group:    group,
 		Version:  apiVersion,
 		Resource: pluralKind,
 	}


### PR DESCRIPTION
Fixes #305
Fixes #189 

Relates to bug #305 - Blocks #198