### PR TITLE
Remove controller-pod-id label

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -72,7 +72,7 @@ func NewResourceGraphDefinitionReconciler(
 		allowCRDDeletion:  allowCRDDeletion,
 		crdManager:        crdWrapper,
 		dynamicController: dynamicController,
-		metadataLabeler:   metadata.NewKroMetaLabeler("0.2.1", "kro-pod"),
+		metadataLabeler:   metadata.NewKroMetaLabeler("0.2.1"),
 		rgBuilder:         builder,
 	}
 }

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -29,9 +29,8 @@ const (
 const (
 	NodeIDLabel = LabelKroPrefix + "node-id"
 
-	OwnedLabel           = LabelKroPrefix + "owned"
-	KroVersionLabel      = LabelKroPrefix + "kro-version"
-	ControllerPodIDLabel = LabelKroPrefix + "controller-pod-id"
+	OwnedLabel      = LabelKroPrefix + "owned"
+	KroVersionLabel = LabelKroPrefix + "kro-version"
 
 	InstanceIDLabel        = LabelKroPrefix + "instance-id"
 	InstanceLabel          = LabelKroPrefix + "instance-name"
@@ -115,8 +114,8 @@ func (gl GenericLabeler) Copy() map[string]string {
 // ResourceGraphDefinitionLabel and ResourceGraphDefinitionIDLabel labels on a resource.
 func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
 	return map[string]string{
-		ResourceGraphDefinitionIDLabel:        string(rgMeta.GetUID()),
-		ResourceGraphDefinitionNameLabel:      rgMeta.GetName(),
+		ResourceGraphDefinitionIDLabel:   string(rgMeta.GetUID()),
+		ResourceGraphDefinitionNameLabel: rgMeta.GetName(),
 	}
 }
 
@@ -131,16 +130,14 @@ func NewInstanceLabeler(instanceMeta metav1.Object) GenericLabeler {
 	}
 }
 
-// NewKroMetaLabeler returns a new labeler that sets the OwnedLabel,
-// KroVersion, and ControllerPodID labels on a resource.
+// NewKroMetaLabeler returns a new labeler that sets the OwnedLabel and
+// KroVersion labels on a resource.
 func NewKroMetaLabeler(
 	kroVersion string,
-	controllerPodID string,
 ) GenericLabeler {
 	return map[string]string{
-		OwnedLabel:           "true",
-		KroVersionLabel:      kroVersion,
-		ControllerPodIDLabel: controllerPodID,
+		OwnedLabel:      "true",
+		KroVersionLabel: kroVersion,
 	}
 }
 


### PR DESCRIPTION
This label is not really useful since pod IDs change in HA setups, making the label meaningless.