### PR TITLE
feat: add go ldflags for version info injection

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -5,3 +5,6 @@ defaultPlatforms:
 defaultLdflags:
   - -s
   - -w
+  - -X github.com/kro-run/kro/pkg.Version={{.Env.RELEASE_VERSION}}
+  - -X github.com/kro-run/kro/pkg.GitCommit={{.Env.GIT_COMMIT}}
+  - -X github.com/kro-run/kro/pkg.BuildDate={{.Env.BUILD_DATE}}

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -72,7 +72,7 @@ func NewResourceGraphDefinitionReconciler(
 		allowCRDDeletion:  allowCRDDeletion,
 		crdManager:        crdWrapper,
 		dynamicController: dynamicController,
-		metadataLabeler:   metadata.NewKROMetaLabeler("0.2.1"),
+		metadataLabeler:   metadata.NewKROMetaLabeler(),
 		rgBuilder:         builder,
 	}
 }

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -17,8 +17,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kro-run/kro/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kro-run/kro/api/v1alpha1"
+	"github.com/kro-run/kro/pkg"
 )
 
 const (
@@ -130,14 +132,12 @@ func NewInstanceLabeler(instanceMeta metav1.Object) GenericLabeler {
 	}
 }
 
-// NewKROMetaLabeler returns a new labeler that sets the OwnedLabel and
-// KROVersion labels on a resource.
-func NewKROMetaLabeler(
-	kroVersion string,
-) GenericLabeler {
+// NewKROMetaLabeler returns a new labeler that sets the OwnedLabel,
+// KROVersion, and ControllerPodID labels on a resource.
+func NewKROMetaLabeler() GenericLabeler {
 	return map[string]string{
 		OwnedLabel:      "true",
-		KROVersionLabel: kroVersion,
+		KROVersionLabel: pkg.Version,
 	}
 }
 

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pkg
+
+// These variables are populated by the go compiler using -ldflags
+var (
+	// Version is the version of the kro binary.
+	Version string // -X github.com/your/repo/pkg.Version=$(VERSION)
+	// GitCommit is the git commit that was compiled.
+	GitCommit string // -X github.com/your/repo/pkg.GitCommit=$(GIT_COMMIT)
+	// BuildDate is the date that the kro binary was built.
+	BuildDate string // -X github.com/your/repo/pkg.BuildDate=$(BUILD_DATE)
+)


### PR DESCRIPTION
Add support for injecting version information at build time via ldflags. This includes:
- Version, git commit hash, and build date injection in `.ko.yaml`
- Updated metadata labeler to use dynamic version
- Makefile updates to support version info injection