### PR TITLE
ci: add Go path filters to Go related workflows

### DIFF
--- a/.github/workflows/build-push-image.yaml
+++ b/.github/workflows/build-push-image.yaml
@@ -4,8 +4,16 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
   pull_request:
     branches: [ main ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
 
 env:
   KO_DOCKER_REPO: ghcr.io/${{ github.repository }}/controller

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**.go"
   pull_request:
     branches:
       - main
+    paths:
+      - "**.go"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,8 +3,16 @@ name: Integration Tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
   pull_request:
     branches: [ main ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
 
 jobs:
   integration:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,8 +2,16 @@ name: unit tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
   pull_request:
     branches: [ main ]
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
 
 jobs:
   build:


### PR DESCRIPTION
Add path filters to only trigger Go related workflows when relevant files change:
   - **.go files
   - go.mod
   - go.sum

(except golangci-lint which is only needed for .go file changes)