### PR TITLE
clusterName field addition to avoid podidentity error

### DIFF
--- a/examples/aws/webstack/Readme.md
+++ b/examples/aws/webstack/Readme.md
@@ -63,6 +63,23 @@ a new file called instance.yaml.
 ```shell
 envsubst < "webstack/instance-tmpl.yaml" > "webstack/instance.yaml"
 ```
+`clusterName` is a required field to achieve pod identity association. If your cluster name is not 'kro' then replace the value assigned to this field in the `webstack/instance.yaml` file with the name of your cluter. 
+
+<pre>
+apiVersion: kro.run/v1alpha1
+kind: WebStack
+metadata:
+  name: test-app
+spec:
+  name: my-test-app-name
+  <mark>clusterName:</mark> kro # change this value if your cluster name is not kro
+  image: candonov/s3-demo-app
+  s3bucket:
+    enabled: true
+    access: write
+  ingress:
+    enabled: true # this will expose unathenticated alb
+  service: {}`</pre>
 
 Apply the `webstack/instance.yaml`
 

--- a/examples/aws/webstack/instance-tmpl.yaml
+++ b/examples/aws/webstack/instance-tmpl.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-app
 spec:
   name: $RESOURCES_NAME
+  clusterName: kro # change this value if your cluster name is not kro
   image: candonov/s3-demo-app
   s3bucket:
     enabled: true


### PR DESCRIPTION
clusterName` is a required field to achieve pod identity association. If the user's cluster name is not 'kro' then pod identity association will fail and we will get output as "unhealthy"