### PR TITLE
fix: handle x-kubernetes-preserve-unknown-fields

### DIFF
--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -81,6 +81,11 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 		return nil, fmt.Errorf("schema is nil")
 	}
 
+	if enabled, ok := schema.VendorExtensible.Extensions["x-kubernetes-preserve-unknown-fields"]; ok && enabled.(bool) {
+		// Handle x-kubernetes-preserve-unknown-fields
+		return e.generateObject(schema)
+	}
+
 	if enabled, ok := schema.VendorExtensible.Extensions["x-kubernetes-int-or-string"]; ok && enabled.(bool) {
 		// Default to integer for dummy CRs
 		return e.generateInteger(schema), nil
@@ -101,7 +106,8 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 
-		return nil, fmt.Errorf("schema type is empty and has no properties")
+    // return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
+    return nil, fmt.Errorf("schema type is empty and has no properties")
 	}
 
 	if len(schema.Type) != 1 {

--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -106,8 +106,8 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 
-    // return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
-    return nil, fmt.Errorf("schema type is empty and has no properties")
+		// return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
+		return nil, fmt.Errorf("schema type is empty and has no properties")
 	}
 
 	if len(schema.Type) != 1 {

--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -106,7 +106,6 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 
-		// return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
 		return nil, fmt.Errorf("schema type is empty and has no properties")
 	}
 

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -14,7 +14,6 @@
 package emulator
 
 import (
-  "fmt" // HACK: remove me, used for debugging, i need to learn to debug better...
 	"strings"
 	"testing"
 

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -14,6 +14,7 @@
 package emulator
 
 import (
+  "fmt" // HACK: remove me, used for debugging, i need to learn to debug better...
 	"strings"
 	"testing"
 
@@ -501,6 +502,24 @@ func TestGenerateValueWithIntOrString(t *testing.T) {
 
 }
 
+func TestGenerateValueWithPreserveUnknownFields(t *testing.T) {
+	e := NewEmulator()
+
+	t.Run("x-kubernetes-preserve-unknown-fields present, does not produce error", func(t *testing.T) {
+		schema := &spec.Schema{
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: map[string]interface{}{
+					"x-kubernetes-preserve-unknown-fields": true,
+				},
+			},
+		}
+
+		value, err := e.generateValue(schema)
+		require.NoError(t, err)
+	})
+
+}
+
 func ptr[T comparable](v T) *T {
 	return &v
 }
@@ -511,6 +530,6 @@ func isInt64OrString(v interface{}) bool {
 	case int64, string:
 		return true
 	default:
-		return false
+	return false
 	}
 }

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -514,7 +514,7 @@ func TestGenerateValueWithPreserveUnknownFields(t *testing.T) {
 			},
 		}
 
-		value, err := e.generateValue(schema)
+		_, err := e.generateValue(schema)
 		require.NoError(t, err)
 	})
 

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -529,6 +529,6 @@ func isInt64OrString(v interface{}) bool {
 	case int64, string:
 		return true
 	default:
-	return false
+		return false
 	}
 }


### PR DESCRIPTION
Handle missing type in schema (generateObject) when x-kubernetes-preserve-unknown-fields is present.

CI checks are passing on my copy/fork of the repo: https://github.com/jknutson/kro/actions

I added a test, but did not include a type check; I did not feel that the goal here was to ensure a specific type.
If it would be valuable, I can add a test to ensure that we have an "object" returned.

This resolves https://github.com/kro-run/kro/issues/319; the failed RGD reconciles as soon as I start up the controller with this change.