### PR TITLE
Remove `metadata.namespace` for LLM storage class example

### DIFF
--- a/examples/aws/llm/llm.yaml
+++ b/examples/aws/llm/llm.yaml
@@ -45,7 +45,6 @@ spec:
       kind: StorageClass
       metadata:
         name: ${schema.spec.name}-storage-class
-        namespace: ${schema.spec.namespace}
         annotations:
           storageclass.kubernetes.io/is-default-class: "true"
       parameters:


### PR DESCRIPTION
Storage Class is Cluster scoped.