### PR TITLE
feat(crd): Prevent breaking changes in RGD schemas

### DIFF
--- a/pkg/graph/crd/compat/changes.go
+++ b/pkg/graph/crd/compat/changes.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compat
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ChangeType represents the type of schema change
+type ChangeType string
+
+const (
+	// Breaking change types
+	PropertyRemoved ChangeType = "PROPERTY_REMOVED"
+	TypeChanged     ChangeType = "TYPE_CHANGED"
+	RequiredAdded   ChangeType = "REQUIRED_ADDED"
+	EnumRestricted  ChangeType = "ENUM_RESTRICTED"
+	PatternChanged  ChangeType = "PATTERN_CHANGED"
+
+	// Non-breaking change types
+	PropertyAdded      ChangeType = "PROPERTY_ADDED"
+	DescriptionChanged ChangeType = "DESCRIPTION_CHANGED"
+	DefaultChanged     ChangeType = "DEFAULT_CHANGED"
+	RequiredRemoved    ChangeType = "REQUIRED_REMOVED"
+	EnumExpanded       ChangeType = "ENUM_EXPANDED"
+)
+
+// Change represents a single schema change
+type Change struct {
+	// Path is the JSON path to the changed property
+	Path string
+	// ChangeType is the type of change
+	ChangeType ChangeType
+	// OldValue is the string representation of the old value (if applicable)
+	OldValue string
+	// NewValue is the string representation of the new value (if applicable)
+	NewValue string
+}
+
+// DiffResult contains the full analysis of schema differences
+type DiffResult struct {
+	// BreakingChanges are changes that break backward compatibility
+	BreakingChanges []Change
+	// NonBreakingChanges are changes that maintain backward compatibility
+	NonBreakingChanges []Change
+}
+
+// HasBreakingChanges returns true if breaking changes were detected
+func (r *DiffResult) HasBreakingChanges() bool {
+	return len(r.BreakingChanges) > 0
+}
+
+// HasChanges returns true if any changes were detected
+func (r *DiffResult) HasChanges() bool {
+	return len(r.BreakingChanges) > 0 || len(r.NonBreakingChanges) > 0
+}
+
+const maxBreakingChangesSummary = 3
+
+// SummarizeBreakingChanges returns a user-friendly summary of breaking changes
+func (r *DiffResult) String() string {
+	if !r.HasBreakingChanges() {
+		return "no breaking changes"
+	}
+
+	changeDescs := make([]string, 0, maxBreakingChangesSummary)
+
+	for i, change := range r.BreakingChanges {
+		// Cut off the summary if there are too many breaking changes
+		if i >= maxBreakingChangesSummary {
+			remaining := len(r.BreakingChanges) - i
+			if remaining > 0 {
+				changeDescs = append(changeDescs, fmt.Sprintf("and %d more changes", remaining))
+			}
+			break
+		}
+		changeDescs = append(changeDescs, change.Description())
+	}
+
+	return strings.Join(changeDescs, "; ")
+}
+
+// AddBreakingChange adds a breaking change to the result with automatically generated description
+func (r *DiffResult) AddBreakingChange(path string, changeType ChangeType, oldValue, newValue string) {
+	r.BreakingChanges = append(r.BreakingChanges, Change{
+		Path:       path,
+		ChangeType: changeType,
+		OldValue:   oldValue,
+		NewValue:   newValue,
+	})
+}
+
+// AddNonBreakingChange adds a non-breaking change to the result with automatically generated description
+func (r *DiffResult) AddNonBreakingChange(path string, changeType ChangeType, oldValue, newValue string) {
+	r.NonBreakingChanges = append(r.NonBreakingChanges, Change{
+		Path:       path,
+		ChangeType: changeType,
+		OldValue:   oldValue,
+		NewValue:   newValue,
+	})
+}
+
+// lastPathComponent extracts the last component from a JSON path
+func lastPathComponent(path string) string {
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 {
+		return path
+	}
+	return parts[len(parts)-1]
+}
+
+// Description generates a human-readable description based on the change type
+func (c Change) Description() string {
+	propName := lastPathComponent(c.Path)
+
+	switch c.ChangeType {
+	case PropertyRemoved:
+		return fmt.Sprintf("Property %s was removed", propName)
+	case PropertyAdded:
+		if c.NewValue == "required" {
+			return fmt.Sprintf("Required property %s was added", propName)
+		}
+		return fmt.Sprintf("Optional property %s was added", propName)
+	case TypeChanged:
+		return fmt.Sprintf("Type changed from %s to %s", c.OldValue, c.NewValue)
+	case RequiredAdded:
+		return fmt.Sprintf("Field %s is newly required", c.NewValue)
+	case RequiredRemoved:
+		return fmt.Sprintf("Field %s is no longer required", c.OldValue)
+	case EnumRestricted:
+		return fmt.Sprintf("Enum value %s was removed", c.OldValue)
+	case EnumExpanded:
+		return fmt.Sprintf("Enum value %s was added", c.NewValue)
+	case PatternChanged:
+		return fmt.Sprintf("Validation pattern changed from %s to %s", c.OldValue, c.NewValue)
+	case DescriptionChanged:
+		return "Description field was changed"
+	case DefaultChanged:
+		return "Default value was changed"
+	default:
+		return fmt.Sprintf("Unknown change to %s", c.Path)
+	}
+}

--- a/pkg/graph/crd/compat/compat.go
+++ b/pkg/graph/crd/compat/compat.go
@@ -1,0 +1,64 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compat
+
+import (
+	"fmt"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// DiffSchema compares schema versions and returns compatibility details.
+// This function expects exactly one version in each slice. If more versions are present,
+// it will return an error as multi-version support is not implemented.
+func DiffSchema(oldVersions []v1.CustomResourceDefinitionVersion, newVersions []v1.CustomResourceDefinitionVersion) (*DiffResult, error) {
+	// Validate single version assumption
+	if len(oldVersions) != 1 || len(newVersions) != 1 {
+		return nil, fmt.Errorf("expected exactly one version in each CRD, got %d old and %d new versions",
+			len(oldVersions), len(newVersions))
+	}
+
+	oldVersion := oldVersions[0]
+	newVersion := newVersions[0]
+
+	// Check version names match
+	if oldVersion.Name != newVersion.Name {
+		return &DiffResult{
+			BreakingChanges: []Change{
+				{
+					Path:       "version",
+					ChangeType: TypeChanged,
+					OldValue:   oldVersion.Name,
+					NewValue:   newVersion.Name,
+				},
+			},
+		}, nil
+	}
+
+	// Verify schemas exist
+	if oldVersion.Schema == nil || oldVersion.Schema.OpenAPIV3Schema == nil {
+		return nil, fmt.Errorf("old version %s has no schema", oldVersion.Name)
+	}
+
+	if newVersion.Schema == nil || newVersion.Schema.OpenAPIV3Schema == nil {
+		return nil, fmt.Errorf("new version %s has no schema", newVersion.Name)
+	}
+
+	// Compare schemas
+	return compareSchemas(
+		fmt.Sprintf("version.%s.schema", oldVersion.Name),
+		oldVersion.Schema.OpenAPIV3Schema,
+		newVersion.Schema.OpenAPIV3Schema,
+	)
+}

--- a/pkg/graph/crd/compat/compat_test.go
+++ b/pkg/graph/crd/compat/compat_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestDiffSchema(t *testing.T) {
+	tests := []struct {
+		name              string
+		oldVersions       []v1.CustomResourceDefinitionVersion
+		newVersions       []v1.CustomResourceDefinitionVersion
+		expectError       bool
+		errorMessage      string
+		expectBreaking    bool
+		breakingCount     int
+		nonBreakingCount  int
+		checkBreakingType ChangeType
+	}{
+		{
+			name: "identical versions",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:    false,
+			expectBreaking: false,
+		},
+		{
+			name: "too many versions",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{Name: "v1"},
+				{Name: "v2"},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{Name: "v1"},
+			},
+			expectError:  true,
+			errorMessage: "expected exactly one version",
+		},
+		{
+			name: "missing schema in old version",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{Type: "object"},
+					},
+				},
+			},
+			expectError:  true,
+			errorMessage: "has no schema",
+		},
+		{
+			name: "missing schema in new version",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{Type: "object"},
+					},
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+				},
+			},
+			expectError:  true,
+			errorMessage: "has no schema",
+		},
+		{
+			name: "breaking change - property removed",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+										"selector": {Type: "object"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:       false,
+			expectBreaking:    true,
+			breakingCount:     1,
+			checkBreakingType: PropertyRemoved,
+		},
+		{
+			name: "non-breaking change - added optional property",
+			oldVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newVersions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &v1.CustomResourceValidation{
+						OpenAPIV3Schema: &v1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]v1.JSONSchemaProps{
+										"replicas": {Type: "integer"},
+										"selector": {Type: "object"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:      false,
+			expectBreaking:   false,
+			nonBreakingCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DiffSchema(tt.oldVersions, tt.newVersions)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMessage != "" {
+					assert.Contains(t, err.Error(), tt.errorMessage)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectBreaking {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges), "Unexpected number of breaking changes")
+
+				if tt.checkBreakingType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.checkBreakingType, result.BreakingChanges[0].ChangeType,
+						"Unexpected breaking change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}

--- a/pkg/graph/crd/compat/doc.go
+++ b/pkg/graph/crd/compat/doc.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package crdcompat provides functionality for comparing Kubernetes CustomResourceDefinition
+// schemas and identifying breaking and non-breaking changes.
+//
+// The package analyzes OpenAPI v3 schemas from CRDs and generates detailed reports about
+// compatibility issues. It's designed to prevent accidental schema changes that would break
+// existing CRD instances.
+//
+// Breaking changes detected include:
+//   - Property removal
+//   - Type changes
+//   - Adding required fields
+//   - Restricting enum values
+//   - Pattern changes
+//
+// Non-breaking changes detected include:
+//   - Adding new properties that are not required
+//   - Expanding enum values
+//   - Changing descriptions
+//   - Changing default values
+//   - Removing optional fields from 'required' list
+//
+// Usage:
+//
+//	// Get existing and new CRD objects
+//	oldCRD, newCRD := getCRDs()
+//
+//	// Compare schemas
+//	diffResult, err := crdcompat.DiffSchema(oldCRD.Spec.Versions, newCRD.Spec.Versions)
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+//	// Check for breaking changes
+//	if diffResult.HasBreakingChanges() {
+//	    summary := diffResult.Summary()
+//	    log.Fatalf("Breaking changes detected: %s", summary)
+//	}
+package compat

--- a/pkg/graph/crd/compat/schema.go
+++ b/pkg/graph/crd/compat/schema.go
@@ -1,0 +1,220 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compat
+
+import (
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// compareSchemas compares two OpenAPIV3Schema objects and returns differences
+func compareSchemas(path string, oldSchema, newSchema *v1.JSONSchemaProps) (*DiffResult, error) {
+	result := &DiffResult{
+		BreakingChanges:    []Change{},
+		NonBreakingChanges: []Change{},
+	}
+
+	// description changes are non-breaking
+	if oldSchema.Description != newSchema.Description {
+		result.AddNonBreakingChange(
+			path+".description",
+			DescriptionChanged,
+			"",
+			"",
+		)
+	}
+
+	// type changes are breaking
+	if oldSchema.Type != newSchema.Type {
+		result.AddBreakingChange(
+			path+".type",
+			TypeChanged,
+			string(oldSchema.Type),
+			string(newSchema.Type),
+		)
+		// return early here to avoid further comparisons...
+		return result, nil
+	}
+
+	// pattern changes are breaking
+	if oldSchema.Pattern != newSchema.Pattern && oldSchema.Pattern != "" && newSchema.Pattern != "" {
+		result.AddBreakingChange(
+			path+".pattern",
+			PatternChanged,
+			oldSchema.Pattern,
+			newSchema.Pattern,
+		)
+	}
+
+	// Compare properties
+	compareProperties(path, oldSchema, newSchema, result)
+
+	// Check required fields
+	compareRequiredFields(path, oldSchema, newSchema, result)
+
+	// Check enum values
+	compareEnumValues(path, oldSchema, newSchema, result)
+
+	// For arrays, check items schema
+	compareArrayItems(path, oldSchema, newSchema, result)
+
+	return result, nil
+}
+
+// compareProperties checks for added, removed, or changed properties
+func compareProperties(path string, oldSchema, newSchema *v1.JSONSchemaProps, result *DiffResult) {
+	// First, check for removed properties (breaking changes)
+	for propName, oldProp := range oldSchema.Properties {
+		propPath := path + ".properties." + propName
+
+		// check if property still exists
+		newProp, exists := newSchema.Properties[propName]
+		if !exists {
+			// property was removed - breaking change
+			result.AddBreakingChange(propPath, PropertyRemoved, "", "")
+			continue
+		}
+
+		// property exists in both schemas - compare them recursively
+		propResult, _ := compareSchemas(propPath, &oldProp, &newProp)
+		result.BreakingChanges = append(result.BreakingChanges, propResult.BreakingChanges...)
+		result.NonBreakingChanges = append(result.NonBreakingChanges, propResult.NonBreakingChanges...)
+	}
+
+	// Then check for added properties. Now things get a bit more spicy.
+	// A new property can be required or optional, and can have a default value.
+	// Depending on these factors, it can be a breaking or non-breaking change.
+	//
+	// In general the rules are:
+	// - Adding a required property without a default value is a breaking change
+	// - Adding a required property with a default value is a non-breaking change
+	// - Adding an optional property is a non-breaking change
+
+	newRequiredSet := toStringSet(newSchema.Required)
+
+	for propName, newProp := range newSchema.Properties {
+		if _, exists := oldSchema.Properties[propName]; !exists {
+			propPath := path + ".properties." + propName
+
+			// check if property is required but has a default (non-breaking)
+			// or required without default (breaking)
+			hasDefault := newProp.Default != nil && len(newProp.Default.Raw) > 0
+
+			if newRequiredSet[propName] && !hasDefault {
+				// property is required and has no default - breaking change
+				result.AddBreakingChange(propPath, PropertyAdded, "required=false", "required=true")
+			} else {
+				// property is optional or has default - non-breaking change
+				result.AddNonBreakingChange(propPath, PropertyAdded, "", "")
+			}
+		}
+	}
+}
+
+// compareRequiredFields checks for changes to required fields, it only considers
+// existing properties, since new properties are handled in compareProperties.
+func compareRequiredFields(path string, oldSchema, newSchema *v1.JSONSchemaProps, result *DiffResult) {
+	// Use length checks instead of nil checks
+	if len(oldSchema.Required) == 0 && len(newSchema.Required) == 0 {
+		return
+	}
+
+	// Convert to sets for efficient comparison
+	oldRequiredSet := toStringSet(oldSchema.Required)
+	newRequiredSet := toStringSet(newSchema.Required)
+
+	// Make a set of all existing property names (not newly added ones)
+	existingProps := make(map[string]bool)
+	for propName := range oldSchema.Properties {
+		existingProps[propName] = true
+	}
+
+	// Check for newly required fields ONLY for existing properties (breaking)
+	for req := range newRequiredSet {
+		// Only consider requirements for properties that already existed
+		if existingProps[req] && !oldRequiredSet[req] {
+			result.AddBreakingChange(path+".required", RequiredAdded, "", req)
+		}
+	}
+
+	// Check for removed required fields (non-breaking)
+	for req := range oldRequiredSet {
+		if !newRequiredSet[req] {
+			result.AddNonBreakingChange(path+".required", RequiredRemoved, req, "")
+		}
+	}
+}
+
+// compareEnumValues checks for changes to enum values
+func compareEnumValues(path string, oldSchema, newSchema *v1.JSONSchemaProps, result *DiffResult) {
+	// Use length checks instead of nil checks
+	if len(oldSchema.Enum) == 0 || len(newSchema.Enum) == 0 {
+		return
+	}
+
+	oldEnumSet := toJsonValueSet(oldSchema.Enum)
+	newEnumSet := toJsonValueSet(newSchema.Enum)
+
+	// Check for removed enum values (breaking)
+	for val := range oldEnumSet {
+		if !newEnumSet[val] {
+			result.AddBreakingChange(path+".enum", EnumRestricted, val, "")
+		}
+	}
+
+	// Check for added enum values (non-breaking)
+	for val := range newEnumSet {
+		if !oldEnumSet[val] {
+			result.AddNonBreakingChange(path+".enum", EnumExpanded, "", val)
+		}
+	}
+}
+
+// compareArrayItems checks array item schemas recursively
+func compareArrayItems(path string, oldSchema, newSchema *v1.JSONSchemaProps, result *DiffResult) {
+	if oldSchema.Type == "array" && newSchema.Type == "array" {
+		// Use safer existence checks
+		oldHasItems := oldSchema.Items != nil && oldSchema.Items.Schema != nil
+		newHasItems := newSchema.Items != nil && newSchema.Items.Schema != nil
+
+		if oldHasItems && newHasItems {
+			itemsResult, _ := compareSchemas(path+".items", oldSchema.Items.Schema, newSchema.Items.Schema)
+			result.BreakingChanges = append(result.BreakingChanges, itemsResult.BreakingChanges...)
+			result.NonBreakingChanges = append(result.NonBreakingChanges, itemsResult.NonBreakingChanges...)
+		} else if oldHasItems && !newHasItems {
+			// Items schema was removed - breaking
+			result.AddBreakingChange(path+".items", PropertyRemoved, "", "")
+		} else if !oldHasItems && newHasItems {
+			// Items schema was added - non-breaking
+			result.AddNonBreakingChange(path+".items", PropertyAdded, "", "")
+		}
+	}
+}
+
+// toStringSet converts a string slice to a map for O(1) lookups
+func toStringSet(slice []string) map[string]bool {
+	set := make(map[string]bool, len(slice))
+	for _, item := range slice {
+		set[item] = true
+	}
+	return set
+}
+
+// toJsonValueSet converts JSON values to strings for comparison
+func toJsonValueSet(values []v1.JSON) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, val := range values {
+		set[string(val.Raw)] = true
+	}
+	return set
+}

--- a/pkg/graph/crd/compat/schema_test.go
+++ b/pkg/graph/crd/compat/schema_test.go
@@ -1,0 +1,566 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestCompareSchemas(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldSchema          *v1.JSONSchemaProps
+		newSchema          *v1.JSONSchemaProps
+		breakingCount      int
+		nonBreakingCount   int
+		expectedChangeType ChangeType
+	}{
+		{
+			name:      "identical schemas",
+			oldSchema: &v1.JSONSchemaProps{Type: "object"},
+			newSchema: &v1.JSONSchemaProps{Type: "object"},
+		},
+		{
+			name:               "changed type",
+			oldSchema:          &v1.JSONSchemaProps{Type: "object"},
+			newSchema:          &v1.JSONSchemaProps{Type: "array"},
+			breakingCount:      1,
+			expectedChangeType: TypeChanged,
+		},
+		{
+			name: "changed description",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "old description",
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "new description",
+			},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "changed pattern",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Pattern: "^[a-z]+$",
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:    "string",
+				Pattern: "^[a-z0-9]+$",
+			},
+			breakingCount:      1,
+			expectedChangeType: PatternChanged,
+		},
+		{
+			name: "multiple breaking changes",
+			oldSchema: &v1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "string"},
+					"prop2": {Type: "integer"},
+					"prop3": {Type: "boolean"},
+				},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "integer"}, // type changed
+					// prop2 removed
+					"prop3": {Type: "boolean"}, // unchanged
+				},
+			},
+			breakingCount: 2,
+		},
+		{
+			name: "multiple non-breaking changes",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "old description",
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "string"},
+				},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "new description",
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "string"},  // Unchanged
+					"prop2": {Type: "integer"}, // Added optional
+				},
+			},
+			nonBreakingCount: 2, // Description changed + new property
+		},
+		{
+			name: "mixed breaking and non-breaking changes",
+			oldSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "old description",
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "string"},
+					"prop2": {Type: "integer"},
+				},
+			},
+			newSchema: &v1.JSONSchemaProps{
+				Type:        "object",
+				Description: "new description", // Non-breaking
+				Properties: map[string]v1.JSONSchemaProps{
+					"prop1": {Type: "boolean"}, // Breaking - type changed
+					// prop2 removed - breaking
+					"prop3": {Type: "string"}, // Non-breaking - added
+				},
+			},
+			breakingCount:    2,
+			nonBreakingCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := compareSchemas("root", tt.oldSchema, tt.newSchema)
+			require.NoError(t, err)
+
+			if tt.breakingCount > 0 {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges), "Unexpected number of breaking changes")
+
+				if tt.expectedChangeType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.expectedChangeType, result.BreakingChanges[0].ChangeType, "Unexpected change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}
+
+func TestCompareProperties(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldProps           map[string]v1.JSONSchemaProps
+		newProps           map[string]v1.JSONSchemaProps
+		oldRequired        []string
+		newRequired        []string
+		breakingCount      int
+		nonBreakingCount   int
+		expectedChangeType ChangeType
+	}{
+		{
+			name: "removed property",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			breakingCount:      1,
+			expectedChangeType: PropertyRemoved,
+		},
+		{
+			name: "multiple removed properties",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+				"prop3": {Type: "boolean"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			breakingCount: 2,
+		},
+		{
+			name: "added optional property",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+			},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "added required property without default",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+			},
+			newRequired:        []string{"prop2"},
+			breakingCount:      1,
+			expectedChangeType: PropertyAdded,
+		},
+		{
+			name: "multiple required properties added without defaults",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+				"prop3": {Type: "boolean"},
+			},
+			newRequired:   []string{"prop2", "prop3"},
+			breakingCount: 2,
+		},
+		{
+			name: "added required property with default",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {
+					Type:    "integer",
+					Default: &v1.JSON{Raw: []byte("42")},
+				},
+			},
+			newRequired:      []string{"prop2"},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "property type change",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "integer"},
+			},
+			breakingCount:      1,
+			expectedChangeType: TypeChanged,
+		},
+		{
+			name: "multiple property type changes",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "boolean"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "integer"},
+				"prop2": {Type: "number"},
+			},
+			breakingCount: 2,
+		},
+		{
+			name: "mixed changes - breaking and non-breaking",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "boolean"}, // removed
+				"prop3": {Type: "integer"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "integer"}, // type changed
+				"prop3": {Type: "integer"}, // unchanged
+				"prop4": {Type: "string"},  // added
+			},
+			breakingCount:    2,
+			nonBreakingCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSchema := &v1.JSONSchemaProps{
+				Type:       "object",
+				Properties: tt.oldProps,
+				Required:   tt.oldRequired,
+			}
+			newSchema := &v1.JSONSchemaProps{
+				Type:       "object",
+				Properties: tt.newProps,
+				Required:   tt.newRequired,
+			}
+
+			result := &DiffResult{}
+			compareProperties("root", oldSchema, newSchema, result)
+
+			if tt.breakingCount > 0 {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges),
+					"Unexpected number of breaking changes")
+
+				if tt.expectedChangeType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.expectedChangeType, result.BreakingChanges[0].ChangeType,
+						"Unexpected change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}
+
+func TestCompareRequiredFields(t *testing.T) {
+	tests := []struct {
+		name              string
+		oldProps          map[string]v1.JSONSchemaProps
+		newProps          map[string]v1.JSONSchemaProps
+		oldRequired       []string
+		newRequired       []string
+		breakingCount     int
+		nonBreakingCount  int
+		checkBreakingType ChangeType
+	}{
+		{
+			name: "no required fields",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+		},
+		{
+			name: "added required field for existing property",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newRequired:       []string{"prop1"},
+			breakingCount:     1,
+			checkBreakingType: RequiredAdded,
+		},
+		{
+			name: "removed required field",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			oldRequired:      []string{"prop1"},
+			nonBreakingCount: 1,
+		},
+		{
+			name: "ignore newly added property in required check",
+			oldProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+			},
+			newProps: map[string]v1.JSONSchemaProps{
+				"prop1": {Type: "string"},
+				"prop2": {Type: "integer"},
+			},
+			newRequired: []string{"prop2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSchema := &v1.JSONSchemaProps{
+				Type:       "object",
+				Properties: tt.oldProps,
+				Required:   tt.oldRequired,
+			}
+			newSchema := &v1.JSONSchemaProps{
+				Type:       "object",
+				Properties: tt.newProps,
+				Required:   tt.newRequired,
+			}
+
+			result := &DiffResult{}
+			compareRequiredFields("root", oldSchema, newSchema, result)
+
+			if tt.breakingCount > 0 {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges), "Unexpected number of breaking changes")
+
+				if tt.checkBreakingType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.checkBreakingType, result.BreakingChanges[0].ChangeType,
+						"Unexpected breaking change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}
+
+func TestCompareEnumValues(t *testing.T) {
+	tests := []struct {
+		name              string
+		oldEnum           []v1.JSON
+		newEnum           []v1.JSON
+		expectBreaking    bool
+		breakingCount     int
+		nonBreakingCount  int
+		checkBreakingType ChangeType
+	}{
+		{
+			name:           "identical enums",
+			oldEnum:        []v1.JSON{{Raw: []byte("\"value1\"")}},
+			newEnum:        []v1.JSON{{Raw: []byte("\"value1\"")}},
+			expectBreaking: false,
+		},
+		{
+			name:              "removed enum value",
+			oldEnum:           []v1.JSON{{Raw: []byte("\"value1\"")}, {Raw: []byte("\"value2\"")}},
+			newEnum:           []v1.JSON{{Raw: []byte("\"value1\"")}},
+			expectBreaking:    true,
+			breakingCount:     1,
+			checkBreakingType: EnumRestricted,
+		},
+		{
+			name:             "added enum value",
+			oldEnum:          []v1.JSON{{Raw: []byte("\"value1\"")}},
+			newEnum:          []v1.JSON{{Raw: []byte("\"value1\"")}, {Raw: []byte("\"value2\"")}},
+			expectBreaking:   false,
+			nonBreakingCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSchema := &v1.JSONSchemaProps{
+				Type: "string",
+				Enum: tt.oldEnum,
+			}
+			newSchema := &v1.JSONSchemaProps{
+				Type: "string",
+				Enum: tt.newEnum,
+			}
+
+			result := &DiffResult{}
+			compareEnumValues("root", oldSchema, newSchema, result)
+
+			if tt.expectBreaking {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges), "Unexpected number of breaking changes")
+
+				if tt.checkBreakingType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.checkBreakingType, result.BreakingChanges[0].ChangeType,
+						"Unexpected breaking change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}
+
+func TestCompareArrayItems(t *testing.T) {
+	tests := []struct {
+		name              string
+		oldItems          *v1.JSONSchemaPropsOrArray
+		newItems          *v1.JSONSchemaPropsOrArray
+		expectBreaking    bool
+		breakingCount     int
+		nonBreakingCount  int
+		checkBreakingType ChangeType
+	}{
+		{
+			name: "identical array items",
+			oldItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "string"},
+			},
+			newItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "string"},
+			},
+			expectBreaking: false,
+		},
+		{
+			name: "changed item type",
+			oldItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "string"},
+			},
+			newItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "integer"},
+			},
+			expectBreaking:    true,
+			breakingCount:     1,
+			checkBreakingType: TypeChanged,
+		},
+		{
+			name: "removed items schema",
+			oldItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "string"},
+			},
+			newItems:          nil,
+			expectBreaking:    true,
+			breakingCount:     1,
+			checkBreakingType: PropertyRemoved,
+		},
+		{
+			name:     "added items schema",
+			oldItems: nil,
+			newItems: &v1.JSONSchemaPropsOrArray{
+				Schema: &v1.JSONSchemaProps{Type: "string"},
+			},
+			expectBreaking:   false,
+			nonBreakingCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSchema := &v1.JSONSchemaProps{
+				Type:  "array",
+				Items: tt.oldItems,
+			}
+			newSchema := &v1.JSONSchemaProps{
+				Type:  "array",
+				Items: tt.newItems,
+			}
+
+			result := &DiffResult{}
+			compareArrayItems("root", oldSchema, newSchema, result)
+
+			if tt.expectBreaking {
+				assert.True(t, result.HasBreakingChanges(), "Expected breaking changes")
+				assert.Equal(t, tt.breakingCount, len(result.BreakingChanges), "Unexpected number of breaking changes")
+
+				if tt.checkBreakingType != "" && len(result.BreakingChanges) > 0 {
+					assert.Equal(t, tt.checkBreakingType, result.BreakingChanges[0].ChangeType,
+						"Unexpected breaking change type")
+				}
+			} else {
+				assert.False(t, result.HasBreakingChanges(), "Expected no breaking changes")
+			}
+
+			if tt.nonBreakingCount > 0 {
+				assert.Equal(t, tt.nonBreakingCount, len(result.NonBreakingChanges),
+					"Unexpected number of non-breaking changes")
+			}
+		})
+	}
+}


### PR DESCRIPTION
`ResourceGraphDefinitions` generate CRDs on the fly, which means one wrong
move in the schema can break existing resources. Deleting a critical field
or switching types can cause immediate deployment failures.

This patch introduces a `DiffSchema` function that systematically compares
old and new schemas, identifying breaking changes like property removals,
type modifications, and constraint updates. It categorizes changes as
breaking or non breaking, allowing safer schema evolution while preventing
accidental resource invalidation.