### PR TITLE
feat: add header configuration to allow vanity go imports

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -32,7 +32,23 @@ const config: Config = {
     defaultLocale: "en",
     locales: ["en"],
   },
-
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        name: "go-import",
+        content: "kro.run/pkg git https://github.com/kro-run/kro",
+      },
+    },
+    {
+      tagName: "meta",
+      attributes: {
+        name: "go-source",
+        content: "kro.run/pkg git https://github.com/kro-run/kro https://github.com/kro-run/kro/tree/main{/dir} https://github.com/kro-run/kro/blob/main{/dir}/{file}#L{line}",
+      },
+    },
+  ],
+  
   presets: [
     [
       "classic",


### PR DESCRIPTION
Fixes #353 

This PR adds support for a Go vanity import path for kro.run/pkg/..., allowing developers to import Kro modules using our own domain instead of the GitHub URL.

