### PR TITLE
standardize `kro/KRO` capitalization per Go style guide

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -22,12 +22,12 @@ import (
 )
 
 const (
-	KroDomainName = "kro.run"
+	KRODomainName = "kro.run"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: KroDomainName, Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: KRODomainName, Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -72,7 +72,7 @@ func NewResourceGraphDefinitionReconciler(
 		allowCRDDeletion:  allowCRDDeletion,
 		crdManager:        crdWrapper,
 		dynamicController: dynamicController,
-		metadataLabeler:   metadata.NewKroMetaLabeler("0.2.1"),
+		metadataLabeler:   metadata.NewKROMetaLabeler("0.2.1"),
 		rgBuilder:         builder,
 	}
 }

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -42,7 +42,7 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx c
 
 	group := rgd.Spec.Schema.Group
 	if group == "" {
-		group = v1alpha1.KroDomainName
+		group = v1alpha1.KRODomainName
 	}
 	// cleanup CRD
 	crdName := extractCRDName(group, rgd.Spec.Schema.Kind)
@@ -78,7 +78,7 @@ func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ct
 }
 
 // extractCRDName generates the CRD name from a given kind by converting it to plural form
-// and appending the Kro domain name.
+// and appending the kro domain name.
 func extractCRDName(group, kind string) string {
 	return fmt.Sprintf("%s.%s",
 		flect.Pluralize(strings.ToLower(kind)),

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -29,7 +29,7 @@ import (
 func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool) *extv1.CustomResourceDefinition {
 	crdGroup := group
 	if crdGroup == "" {
-		crdGroup = v1alpha1.KroDomainName
+		crdGroup = v1alpha1.KRODomainName
 	}
 	return newCRD(crdGroup, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride))
 }

--- a/pkg/metadata/finalizers.go
+++ b/pkg/metadata/finalizers.go
@@ -22,21 +22,21 @@ import (
 	"github.com/kro-run/kro/api/v1alpha1"
 )
 
-const kroFinalizer = v1alpha1.KroDomainName + "/finalizer"
+const kroFinalizer = v1alpha1.KRODomainName + "/finalizer"
 
-// SetResourceGraphDefinitionFinalizer adds the Kro finalizer to the object if it's not already present.
+// SetResourceGraphDefinitionFinalizer adds the kro finalizer to the object if it's not already present.
 func SetResourceGraphDefinitionFinalizer(obj metav1.Object) {
 	if !HasResourceGraphDefinitionFinalizer(obj) {
 		obj.SetFinalizers(append(obj.GetFinalizers(), kroFinalizer))
 	}
 }
 
-// RemoveResourceGraphDefinitionFinalizer removes the Kro finalizer from the object.
+// RemoveResourceGraphDefinitionFinalizer removes the kro finalizer from the object.
 func RemoveResourceGraphDefinitionFinalizer(obj metav1.Object) {
 	obj.SetFinalizers(removeString(obj.GetFinalizers(), kroFinalizer))
 }
 
-// HasResourceGraphDefinitionFinalizer checks if the object has the Kro finalizer.
+// HasResourceGraphDefinitionFinalizer checks if the object has the kro finalizer.
 func HasResourceGraphDefinitionFinalizer(obj metav1.Object) bool {
 	return containsString(obj.GetFinalizers(), kroFinalizer)
 }

--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	KroInstancesGroupSuffix = v1alpha1.KroDomainName
+	KROInstancesGroupSuffix = v1alpha1.KRODomainName
 )
 
 // ExtractGVKFromUnstructured extracts the GroupVersionKind from an unstructured object.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -22,39 +22,39 @@ import (
 )
 
 const (
-	// LabelKro is the label key used to identify Kro owned resources.
-	LabelKroPrefix = v1alpha1.KroDomainName + "/"
+	// LabelKROPrefix is the label key prefix used to identify KRO owned resources.
+	LabelKROPrefix = v1alpha1.KRODomainName + "/"
 )
 
 const (
-	NodeIDLabel = LabelKroPrefix + "node-id"
+	NodeIDLabel = LabelKROPrefix + "node-id"
 
-	OwnedLabel      = LabelKroPrefix + "owned"
-	KroVersionLabel = LabelKroPrefix + "kro-version"
+	OwnedLabel      = LabelKROPrefix + "owned"
+	KROVersionLabel = LabelKROPrefix + "kro-version"
 
-	InstanceIDLabel        = LabelKroPrefix + "instance-id"
-	InstanceLabel          = LabelKroPrefix + "instance-name"
-	InstanceNamespaceLabel = LabelKroPrefix + "instance-namespace"
+	InstanceIDLabel        = LabelKROPrefix + "instance-id"
+	InstanceLabel          = LabelKROPrefix + "instance-name"
+	InstanceNamespaceLabel = LabelKROPrefix + "instance-namespace"
 
-	ResourceGraphDefinitionIDLabel        = LabelKroPrefix + "resource-graph-definition-id"
-	ResourceGraphDefinitionNameLabel      = LabelKroPrefix + "resource-graph-definition-name"
-	ResourceGraphDefinitionNamespaceLabel = LabelKroPrefix + "resource-graph-definition-namespace"
-	ResourceGraphDefinitionVersionLabel   = LabelKroPrefix + "resource-graph-definition-version"
+	ResourceGraphDefinitionIDLabel        = LabelKROPrefix + "resource-graph-definition-id"
+	ResourceGraphDefinitionNameLabel      = LabelKROPrefix + "resource-graph-definition-name"
+	ResourceGraphDefinitionNamespaceLabel = LabelKROPrefix + "resource-graph-definition-namespace"
+	ResourceGraphDefinitionVersionLabel   = LabelKROPrefix + "resource-graph-definition-version"
 )
 
-// IsKroOwned returns true if the resource is owned by Kro.
-func IsKroOwned(meta metav1.ObjectMeta) bool {
+// IsKROOwned returns true if the resource is owned by KRO.
+func IsKROOwned(meta metav1.ObjectMeta) bool {
 	v, ok := meta.Labels[OwnedLabel]
 	return ok && booleanFromString(v)
 }
 
-// SetKroOwned sets the OwnedLabel to true on the resource.
-func SetKroOwned(meta metav1.ObjectMeta) {
+// SetKROOwned sets the OwnedLabel to true on the resource.
+func SetKROOwned(meta metav1.ObjectMeta) {
 	setLabel(&meta, OwnedLabel, stringFromBoolean(true))
 }
 
-// SetKroUnowned sets the OwnedLabel to false on the resource.
-func SetKroUnowned(meta metav1.ObjectMeta) {
+// SetKROUnowned sets the OwnedLabel to false on the resource.
+func SetKROUnowned(meta metav1.ObjectMeta) {
 	setLabel(&meta, OwnedLabel, stringFromBoolean(false))
 }
 
@@ -130,14 +130,14 @@ func NewInstanceLabeler(instanceMeta metav1.Object) GenericLabeler {
 	}
 }
 
-// NewKroMetaLabeler returns a new labeler that sets the OwnedLabel and
-// KroVersion labels on a resource.
-func NewKroMetaLabeler(
+// NewKROMetaLabeler returns a new labeler that sets the OwnedLabel and
+// KROVersion labels on a resource.
+func NewKROMetaLabeler(
 	kroVersion string,
 ) GenericLabeler {
 	return map[string]string{
 		OwnedLabel:      "true",
-		KroVersionLabel: kroVersion,
+		KROVersionLabel: kroVersion,
 	}
 }
 

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -30,19 +30,19 @@ func (m *mockObject) GetObjectMeta() metav1.Object {
 	return m
 }
 
-func TestIsKroOwned(t *testing.T) {
+func TestIsKROOwned(t *testing.T) {
 	cases := []struct {
 		name     string
 		labels   map[string]string
 		expected bool
 	}{
 		{
-			name:     "owned by Kro",
+			name:     "owned by kro",
 			labels:   map[string]string{OwnedLabel: "true"},
 			expected: true,
 		},
 		{
-			name:     "not owned by Kro",
+			name:     "not owned by kro",
 			labels:   map[string]string{OwnedLabel: "false"},
 			expected: false,
 		},
@@ -56,13 +56,13 @@ func TestIsKroOwned(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			meta := metav1.ObjectMeta{Labels: tc.labels}
-			result := IsKroOwned(meta)
+			result := IsKROOwned(meta)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 }
 
-func TestSetKroOwned(t *testing.T) {
+func TestSetKROOwned(t *testing.T) {
 	cases := []struct {
 		name          string
 		initialLabels map[string]string
@@ -83,13 +83,13 @@ func TestSetKroOwned(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			meta := metav1.ObjectMeta{Labels: tc.initialLabels}
-			SetKroOwned(meta)
+			SetKROOwned(meta)
 			assert.Equal(t, tc.expected, meta.Labels)
 		})
 	}
 }
 
-func TestSetKroUnowned(t *testing.T) {
+func TestSetKROUnowned(t *testing.T) {
 	cases := []struct {
 		name          string
 		initialLabels map[string]string
@@ -110,7 +110,7 @@ func TestSetKroUnowned(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			meta := metav1.ObjectMeta{Labels: tc.initialLabels}
-			SetKroUnowned(meta)
+			SetKROUnowned(meta)
 			assert.Equal(t, tc.expected, meta.Labels)
 		})
 	}

--- a/test/integration/suites/ackekscluster/generator.go
+++ b/test/integration/suites/ackekscluster/generator.go
@@ -66,7 +66,7 @@ func eksCluster(
 	instanceGenerator := func(namespace, name, version string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "EKSCluster",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/test/integration/suites/core/conditional_test.go
+++ b/test/integration/suites/core/conditional_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Conditions", func() {
 		// Create instance
 		instance := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "TestConditions",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/test/integration/suites/core/lifecycle_test.go
+++ b/test/integration/suites/core/lifecycle_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Update", func() {
 		// Create initial instance
 		instance := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "TestUpdate",
 				"metadata": map[string]interface{}{
 					"name":      "test-instance-for-updates",

--- a/test/integration/suites/core/readiness_test.go
+++ b/test/integration/suites/core/readiness_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Readiness", func() {
 		// Create instance
 		instance := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "TestReadiness",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/test/integration/suites/core/recover_test.go
+++ b/test/integration/suites/core/recover_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Recovery", func() {
 		name := "test-recovery"
 		instance := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "TestRecovery",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/test/integration/suites/deploymentservice/generator.go
+++ b/test/integration/suites/deploymentservice/generator.go
@@ -46,7 +46,7 @@ func deploymentService(
 	instanceGenerator := func(namespace, name string, port int) *unstructured.Unstructured {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "DeploymentService",
 				"metadata": map[string]interface{}{
 					"name":      name,

--- a/test/integration/suites/networkingstack/generator.go
+++ b/test/integration/suites/networkingstack/generator.go
@@ -53,7 +53,7 @@ func networkingStack(
 	instanceGenerator := func(namespace, name string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KroDomainName, "v1alpha1"),
+				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
 				"kind":       "NetworkingStack",
 				"metadata": map[string]interface{}{
 					"name":      name,


### PR DESCRIPTION
Use uppercase for the KRO acronym throughout the codebase for consistency with
Go style guide: https://google.github.io/styleguide/go/decisions#initialisms