### PR TITLE
feat: Fine-grained RBAC in the Helm chart

### DIFF
--- a/helm/templates/cluster-role-binding.yaml
+++ b/helm/templates/cluster-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kro.fullname" . }}-role-binding
+  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role-binding{{- else -}}:controller{{- end }}
   labels:
     {{- include "kro.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: {{ include "kro.fullname" . }}-cluster-role
+  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role{{- else -}}:controller{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kro.serviceAccountName" . }}

--- a/helm/templates/cluster-role-binding.yaml
+++ b/helm/templates/cluster-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role-binding{{- else -}}:controller{{- end }}
+  name: {{ include "kro.fullname" . }}{{- if eq .Values.rbac.mode "unrestricted" -}}-cluster-role-binding{{- else -}}:controller{{- end }}
   labels:
     {{- include "kro.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role{{- else -}}:controller{{- end }}
+  name: {{ include "kro.fullname" . }}{{- if eq .Values.rbac.mode "unrestricted" -}}-cluster-role{{- else -}}:controller{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kro.serviceAccountName" . }}

--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -4,12 +4,12 @@ metadata:
   annotations:
     kubernetes.io/description: |
 {{- if .Values.rbac.legacy }}
-      This ClusterRole grants cluster-wide admin access for the Kro controller.
+      This ClusterRole grants cluster-wide admin access for the kro controller.
 {{- else }}
-      This ClusterRole grants access for the Kro controller.
+      This ClusterRole grants access for the kro controller.
 
-      The Kro installation comes with enough for the controller to run, and start watching the relevant resources
-      (e.g. ResourceGraphDefinitions), but in order to allow Kro to create and manage other types of resoruces you
+      The kro installation comes with enough for the controller to run, and start watching the relevant resources
+      (e.g. ResourceGraphDefinitions), but in order to allow kro to create and manage other types of resoruces you
       must manually grant access to those separately.
 
       The easiest way to accomplish this is to create a new ClusterRole with the label `rbac.kro.run/aggregate-to-controller: "true"`
@@ -37,7 +37,7 @@ kind: ClusterRole
 metadata:
   annotations:
     kubernetes.io/description: |
-      This ClusterRole grants access for the Kro controller to resources it always needs access to.
+      This ClusterRole grants access for the kro controller to resources it always needs access to.
   labels:
     {{- include "kro.labels" . | nindent 4 }}
     rbac.kro.run/aggregate-to-controller: "true"

--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -15,10 +15,10 @@ metadata:
       The easiest way to accomplish this is to create a new ClusterRole with the label `rbac.kro.run/aggregate-to-controller: "true"`
       which will be automatically aggregated into this one.
 {{- end }}
-  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role{{- else -}}:controller{{- end }}
+  name: {{ include "kro.fullname" . }}{{- if eq .Values.rbac.mode "unrestricted" -}}-cluster-role{{- else -}}:controller{{- end }}
   labels:
     {{- include "kro.labels" . | nindent 4 }}
-{{ if .Values.rbac.legacy -}}
+{{ if eq .Values.rbac.mode "unrestricted" -}}
 rules:
 - apiGroups:
   - "*"
@@ -26,7 +26,7 @@ rules:
   - "*"
   verbs:
   - '*'
-{{ else if not .Values.rbac.legacy -}}
+{{ else if eq .Values.rbac.mode "aggregation" -}}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -1,9 +1,24 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kro.fullname" . }}-cluster-role
+  annotations:
+    kubernetes.io/description: |
+{{- if .Values.rbac.legacy }}
+      This ClusterRole grants cluster-wide admin access for the Kro controller.
+{{- else }}
+      This ClusterRole grants access for the Kro controller.
+
+      The Kro installation comes with enough for the controller to run, and start watching the relevant resources
+      (e.g. ResourceGraphDefinitions), but in order to allow Kro to create and manage other types of resoruces you
+      must manually grant access to those separately.
+
+      The easiest way to accomplish this is to create a new ClusterRole with the label `rbac.kro.run/aggregate-to-controller: "true"`
+      which will be automatically aggregated into this one.
+{{- end }}
+  name: {{ include "kro.fullname" . }}{{- if .Values.rbac.legacy -}}-cluster-role{{- else -}}:controller{{- end }}
   labels:
     {{- include "kro.labels" . | nindent 4 }}
+{{ if .Values.rbac.legacy -}}
 rules:
 - apiGroups:
   - "*"
@@ -11,3 +26,47 @@ rules:
   - "*"
   verbs:
   - '*'
+{{ else if not .Values.rbac.legacy -}}
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        'rbac.kro.run/aggregate-to-controller': "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      This ClusterRole grants access for the Kro controller to resources it always needs access to.
+  labels:
+    {{- include "kro.labels" . | nindent 4 }}
+    rbac.kro.run/aggregate-to-controller: "true"
+  name: {{ include "kro.fullname" . }}:controller:static
+rules:
+- apiGroups:
+  - kro.run
+  resources:
+  - resourcegraphdefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kro.run
+  resources:
+  - resourcegraphdefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kro.run
+  resources:
+  - resourcegraphdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}

--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -69,4 +69,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - delete
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  legacy: true
+
 deployment:
   # Number of replicas for the Pods to run
   replicaCount: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,7 +32,16 @@ serviceAccount:
   name: ""
 
 rbac:
-  legacy: true
+  # Specifies how to manage access for kro in the cluster
+  # Two modes are currently supported:
+  # - unrestricted: Grants cluster-wide full access to all resources
+  # - aggregation: Grants a minimal set of permissions for kro to manage its own
+  #                resources, and additionally aggregates ClusterRoles with the
+  #                label `rbac.kro.run/aggregate-to-controller: "true"` to allow
+  #                kro users to extend kro's permissions.
+  # Recommended setting is aggregation, but unrestricted remains the default for
+  # backwards compatibility.
+  mode: unrestricted
 
 deployment:
   # Number of replicas for the Pods to run

--- a/website/docs/docs/concepts/20-access-control.md
+++ b/website/docs/docs/concepts/20-access-control.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 20
+---
+
+# Access Control
+
+There are currently two modes of access control supported by **kro**, if you
+[install through the Helm chart](../getting-started/01-Installation.md#install-kro-using-helm):
+
+- `unrestricted`
+
+- `aggregation`
+
+The mode is selected with a `values` property `rbac.mode`, and defaults to `unrestricted`.
+
+## `unrestricted` Access
+
+In the `unrestricted` access mode, the chart includes a `ClusterRole` granting
+**kro** _full control to every resource type in your cluster_. This can be
+useful for experimenting in a test environment, where access control is not
+necessary, but is not recommended in a production environment.
+
+In this mode, anyone with access to create `ResourceGraphDefinition` resources,
+effectively also has admin access to the cluster.
+
+## `aggregation` Access
+
+In the `aggreagation` access mode, the chart includes an [_aggregated_ `ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
+which dynamically includes all rules from all `ClusterRoles` that have the label
+`rbac.kro.run/aggregate-to-controller: "true"`.
+
+There is a very minimal set of permissions provisioned by the chart itself, just
+enough to let **kro** run at all: full permissions for `ResourceGraphDefinition`s
+and its subresources, and full permissions for `CustomResourceDefinitions` as
+**kro** will create them in response to the existence of an RGD.
+
+However, this does _not_ automatically set up permissions for **kro** to actually
+reconcile those generated CRDs! In other words, when using this mode, you will
+need to provision additional access for **kro** for every new resource type you
+define.
+
+### Example
+
+If you want to create a `ResourceGraphDefinition` that specifies a new resource
+type with `kind: Foo`, and where the graph includes an `apps/v1/Deployment` and
+a `v1/ConfigMap`, you will need to create the following `ClusterRole` to ensure
+**kro** has enough access to reconcile your resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.kro.run/aggregate-to-controller: "true"
+  name: kro:controller:foos
+rules:
+  - apiGroups:
+      - kro.run
+    resources:
+      - foos
+    verbs:
+      - "*"
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - "*"
+```


### PR DESCRIPTION
This PR introduces a new scheme for configuring RBAC through the Helm chart.

The basic approach mimics [what Kyverno does](https://kyverno.io/docs/installation/customization/#role-based-access-controls), so there is some industry precedent for this approach, and the aggregation feature it relies on is [long-time supported in Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).

To enable this in your deployment, set

```yaml
rbac:
  legacy: false
```

in your `values.yaml` file. You'll then need to create `ClusterRole`s with the label `rbac.kro.run/aggregate-to-controller: "true"` to grant any access you want to give Kro outside the bare-minimum set of permissions the Helm chart will now include.

Fixes #230.
