### PR TITLE
fix: gcp cloudsql example fails to deploy

### DIFF
--- a/examples/gcp/cloud-sql/rgd.yaml
+++ b/examples/gcp/cloud-sql/rgd.yaml
@@ -139,7 +139,7 @@ spec:
         role: roles/cloudkms.cryptoKeyEncrypterDecrypter
         resourceRef:
           kind: KMSCryptoKey
-          name: ${kmskeyPrimary.metadata.name}-primary
+          name: ${kmskeyPrimary.metadata.name}
           #namespace: {{ cloudsqls.metadata.namespace }}
   - id: iampolicymemberReplica
     template:
@@ -154,7 +154,7 @@ spec:
         role: roles/cloudkms.cryptoKeyEncrypterDecrypter
         resourceRef:
           kind: KMSCryptoKey
-          name: ${kmskeyReplica.metadata.name}-replica
+          name: ${kmskeyReplica.metadata.name}
           #namespace: {{ cloudsqls.metadata.namespace }}
   - id: sqlPrimary
     template:
@@ -181,6 +181,7 @@ spec:
             location: us
           diskSize: 50
           diskType: PD_SSD
+          edition: ENTERPRISE
           maintenanceWindow:
             day: 7
             hour: 3
@@ -200,12 +201,14 @@ spec:
         databaseVersion: POSTGRES_13
         encryptionKMSCryptoKeyRef:
           external: projects/${schema.spec.project}/locations/${schema.spec.replicaRegion}/keyRings/${keyringReplica.metadata.name}/cryptoKeys/${kmskeyReplica.metadata.name}
+        instanceType: READ_REPLICA_INSTANCE
         masterInstanceRef:
           name: ${schema.spec.name}-primary
           #namespace: {{ cloudsqls.metadata.namespace }}
         region: ${schema.spec.replicaRegion}
         settings:
-          availabilityType: REGIONAL
+          availabilityType: ZONAL
           diskSize: 50
           diskType: PD_SSD
+          edition: ENTERPRISE
           tier: db-custom-8-30720


### PR DESCRIPTION
Fixes #369 

- Fixes iampolicymember naming issues
- Fixes the inability to deploy SQL instance replica
