### PR TITLE
Enable OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish job below).
+      id-token: write
+      # Uncomment the permissions below if you want to contribute your results to the OpenSSF dashboard.
+      # contents: read
+      # id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the line below if you want to enable the Branch-Protection check on a private repository.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.2.7
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![GitHub License](https://img.shields.io/github/license/kro-run/kro)
 [![Build and Publish](https://github.com/kro-run/kro/actions/workflows/build-push-image.yaml/badge.svg?branch=main)](https://github.com/kro-run/kro/actions/workflows/build-push-image.yaml)
 ![GitHub Repo stars](https://img.shields.io/github/stars/kro-run/kro)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kro-run/kro/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kro-run/kro)
 
 This project aims to simplify the creation and management of complex custom resources for Kubernetes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,28 @@
-# Security issue notifications
+# Security Policy
+
+## Reporting a Vulnerability
 
 If you discover a potential security issue in this project we ask that you
 notify AWS/Amazon Security via our
 [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
-Please do **not** create a public github issue.
+Please do **not** create a public GitHub issue.
+
+## Security Measures
+
+### OpenSSF Scorecard
+
+This project uses the [OpenSSF Scorecard](https://securityscorecards.dev/) to continuously monitor and improve our security posture. The Scorecard checks for adherence to security best practices and provides a score based on various security criteria. You can view our current score by clicking on the Scorecard badge in our README.
+
+### Security Best Practices
+
+We strive to follow these security best practices:
+
+- Regular dependency updates and vulnerability scanning
+- Code review requirements for all changes
+- Automated testing for security issues
+- Proper branch protection rules
+- Signed commits and releases
+
+### Security Updates
+
+Security updates and patches are applied on a regular basis. We encourage all users to keep their dependencies up to date.

--- a/docs/security/scorecard.md
+++ b/docs/security/scorecard.md
@@ -1,0 +1,77 @@
+# OpenSSF Scorecard Guide
+
+## Overview
+
+The [OpenSSF Scorecard](https://securityscorecards.dev/) is an automated tool that assesses open source projects for security risks. It runs a series of checks against your repository to evaluate security best practices and provides a score that helps identify areas for improvement.
+
+## How It Works
+
+The Scorecard workflow has been set up in `.github/workflows/scorecard.yml` and runs:
+- On a weekly schedule (every Tuesday at 7:20 UTC)
+- When changes are pushed to the main branch
+- When branch protection rules are modified
+
+The workflow performs various security checks and:
+1. Uploads results as a GitHub artifact
+2. Publishes results to GitHub's code scanning dashboard
+3. Publishes results to the public Scorecard API (which powers the badge in our README)
+
+## Scorecard Checks
+
+Scorecard evaluates your project on multiple security criteria, including:
+
+| Check | Description |
+|-------|-------------|
+| **Branch Protection** | Verifies that the repository has branch protection rules enabled |
+| **Code Review** | Checks if the project requires code reviews before merging code |
+| **Dependencies** | Evaluates how dependencies are managed and updated |
+| **Maintained** | Checks if the project is actively maintained |
+| **Vulnerabilities** | Looks for unfixed vulnerabilities |
+| **CI Tests** | Verifies that CI tests are run on pull requests |
+| **Dangerous Workflows** | Identifies dangerous patterns in GitHub Actions workflows |
+| **Binary Artifacts** | Checks for binary artifacts in the repository |
+| **SAST** | Verifies if Static Application Security Testing is used |
+| **Token Permissions** | Checks if GitHub workflows follow the principle of least privilege |
+
+## Improving Your Score
+
+To improve your Scorecard results:
+
+1. **Enable branch protection rules** for your main branch
+   - Require pull request reviews before merging
+   - Require status checks to pass before merging
+   - Restrict who can push to matching branches
+
+2. **Implement dependency management**
+   - Use Dependabot or similar tools to keep dependencies updated
+   - Regularly audit and update dependencies
+
+3. **Maintain the project actively**
+   - Respond to issues and pull requests
+   - Regularly commit to the repository
+
+4. **Implement security scanning**
+   - Add CodeQL or other SAST tools to your CI pipeline
+   - Run vulnerability scanning on dependencies
+
+5. **Follow least privilege principle**
+   - Use read-only tokens when possible in GitHub Actions
+   - Limit permissions to what's necessary
+
+6. **Sign your releases and commits**
+   - Use GPG to sign commits and tags
+   - Verify signatures on dependencies
+
+## Viewing Your Results
+
+You can view your Scorecard results in several ways:
+- Click the Scorecard badge in the README
+- Check the GitHub Actions workflow run
+- View the uploaded SARIF file in GitHub's code scanning dashboard
+
+## Resources
+
+- [OpenSSF Scorecard Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
+- [GitHub Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
+- [Dependabot Configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
+- [GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning)


### PR DESCRIPTION
Enabled [OpenSSF Scorecard](https://github.com/ossf/scorecard) GitHub Action to continuously assess and monitor the security posture of the project. The Scorecard runs automated security checks on every push to the main branch and publishes results to the OpenSSF Security Dashboard.

related #390 