### PR TITLE
Cleanup : unused `ExpectedTypes` field and `ExpectedSchema` mismatch in `parser_test.go`

### DIFF
--- a/pkg/graph/parser/parser_test.go
+++ b/pkg/graph/parser/parser_test.go
@@ -1196,6 +1196,18 @@ func TestOneOfWithStructuralConstraints(t *testing.T) {
 		if !reflect.DeepEqual(expressions[0].Path, expected.Path) {
 			t.Errorf("Expected path %s, got %s", expected.Path, expressions[0].Path)
 		}
+
+		if !reflect.DeepEqual(expressions[0].Expressions, expected.Expressions) {
+			t.Errorf("Expressions mismatch: got %v, want %v", expressions[0].Expressions, expected.Expressions)
+		}
+
+		if !reflect.DeepEqual(expressions[0].ExpectedTypes, expected.ExpectedTypes) {
+			t.Errorf("ExpectedTypes mismatch: got %v, want %v", expressions[0].ExpectedTypes, expected.ExpectedTypes)
+		}
+
+		if expressions[0].StandaloneExpression != expected.StandaloneExpression {
+			t.Errorf("StandaloneExpression mismatch: got %v, want %v", expressions[0].StandaloneExpression, expected.StandaloneExpression)
+		}
 	})
 
 	t.Run("networkRef with external reference", func(t *testing.T) {
@@ -1283,6 +1295,10 @@ func TestOneOfWithStructuralConstraints(t *testing.T) {
 		}
 		if !reflect.DeepEqual(expressions[0].ExpectedTypes, expected.ExpectedTypes) {
 			t.Errorf("Expected types %v, got %v", expected.ExpectedTypes, expressions[0].ExpectedTypes)
+		}
+
+		if expressions[0].StandaloneExpression != expected.StandaloneExpression {
+			t.Errorf("StandaloneExpression mismatch: got %v, want %v", expressions[0].StandaloneExpression, expected.StandaloneExpression)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #398 


Before there was unused  ExpectedTypes field and ExpectedSchema mismatch

<img width="1470" alt="Screenshot 2025-03-16 at 5 59 53 PM" src="https://github.com/user-attachments/assets/90f97a8c-ab32-4535-89c6-8ee89be859a9" />


After 

<img width="1470" alt="Screenshot 2025-03-16 at 6 00 14 PM" src="https://github.com/user-attachments/assets/108d4467-6417-453e-880a-cdc2f92022c8" />



# Testting

Tested the code with 

go test ./pkg/graph/parser -v

which shows all test cases passed 

so currently it uses everyExpectedTypes field so no  ExpectedSchema mismatch in parser_test.go  and everything works fine

cc:@a-hilaly 

