### PR TITLE
fix: correct patches array format in `config/crd/kustomization.yaml`

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,8 +5,7 @@ resources:
 - bases/kro.run_resourcegraphdefinitions.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patches:
-[]
+patches: []
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- path: patches/webhook_in_resourcegraphdefinitions.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:
+[]
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- path: patches/webhook_in_resourcegraphdefinitions.yaml


### PR DESCRIPTION
Fixes #411 

- Changes patches field from '[]' to proper YAML array format
- Fixes YAML schema validation error
- Maintains kubebuilder scaffold structure

## Before 

<img width="1157" alt="Screenshot 2025-03-18 at 12 33 10 PM" src="https://github.com/user-attachments/assets/82e32aec-5928-4f99-b40e-c38707e67abb" />


## After

<img width="673" alt="Screenshot 2025-03-18 at 12 40 36 PM" src="https://github.com/user-attachments/assets/942f9829-106f-47e6-95db-25337d6d87ea" />

cc: @a-hilaly 