### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -91,7 +91,7 @@ func main() {
 		"dynamic-controller-concurrent-reconciles", 1,
 		"The number of dynamic controller reconciles to run in parallel",
 	)
-	// reconciler parametes
+	// reconciler parameters
 	flag.IntVar(&resyncPeriod, "dynamic-controller-default-resync-period", 10,
 		"interval at which the controller will re list resources even with no changes, in hours")
 	flag.IntVar(&queueMaxRetries, "dynamic-controller-default-queue-max-retries", 20,

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kro-run/kro/pkg/metadata"
 )
 
-// ReconcileConfig holds configuration parameters for the recnociliation process.
+// ReconcileConfig holds configuration parameters for the reconciliation process.
 // It allows the customization of various aspects of the controller's behavior.
 type ReconcileConfig struct {
 	// DefaultRequeueDuration is the default duration to wait before requeueing a
@@ -128,7 +128,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) error {
 	}
 
 	// This is one of the main reasons why we're splitting the controller into
-	// two parts. The instanciator is responsible for creating a new runtime
+	// two parts. The instantiator is responsible for creating a new runtime
 	// instance of the resource graph definition. The instance graph reconciler is responsible
 	// for reconciling the instance and its sub-resources, while keeping the same
 	// runtime object in it's fields.

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -38,7 +38,7 @@
 //
 // Why not use k8s.io/controller-runtime:
 //
-//  1. Staticc nature: controller-runtime is optimized for statically defined
+//  1. Static nature: controller-runtime is optimized for statically defined
 //     controllers, however kro requires runtime creation and management
 //     of controllers for various GVRs.
 //
@@ -90,7 +90,7 @@ type Config struct {
 	// will be retried before being dropped.
 	//
 	// NOTE(a-hilaly): I'm not very sure how useful is this, i'm trying to avoid
-	// situations where reconcile errors exauhst the queue.
+	// situations where reconcile errors exhaust the queue.
 	QueueMaxRetries int
 	// ShutdownTimeout is the maximum duration to wait for the controller to
 	// gracefully shutdown. We ideally want to avoid forceful shutdowns, giving

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -67,7 +67,7 @@ func NewBuilder(
 //
 // The GraphBuild performs several key functions:
 //
-//	  1/ It validates the resource deinitions and their naming conventions.
+//	  1/ It validates the resource definitions and their naming conventions.
 //	  2/ It interacts with the API Server to retrieve the OpenAPI schema for the
 //	     resources, and validates the resources against the schema.
 //	  3/ Extracts and processes the CEL expressions from the resources definitions.
@@ -249,10 +249,10 @@ func (b *Builder) NewResourceGraphDefinition(originalCR *v1alpha1.ResourceGraphD
 
 // buildRGResource builds a resource from the given resource definition.
 // It provides a high-level understanding of the resource, by extracting the
-// OpenAPI schema, emualting the resource and extracting the cel expressions
+// OpenAPI schema, emulating the resource and extracting the cel expressions
 // from the schema.
 func (b *Builder) buildRGResource(rgResource *v1alpha1.Resource, namespacedResources map[k8sschema.GroupKind]bool, order int) (*Resource, error) {
-	// 1. We need to unmashal the resource into a map[string]interface{} to
+	// 1. We need to unmarshal the resource into a map[string]interface{} to
 	//    make it easier to work with.
 	resourceObject := map[string]interface{}{}
 	err := yaml.UnmarshalStrict(rgResource.Template.Raw, &resourceObject)

--- a/pkg/graph/dag/dag.go
+++ b/pkg/graph/dag/dag.go
@@ -26,7 +26,7 @@ import (
 type Vertex struct {
 	// ID is a unique identifier for the node
 	ID string
-	// Order records the original order, and is used to preserve the original user-provided ordering as far as posible.
+	// Order records the original order, and is used to preserve the original user-provided ordering as far as possible.
 	Order int
 	// DependsOn stores the IDs of the nodes that this node depends on.
 	// If we depend on another vertex, we must appear after that vertex in the topological sort.

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -142,7 +142,7 @@ func NewKROMetaLabeler() GenericLabeler {
 }
 
 func booleanFromString(s string) bool {
-	// for the sake of simplicy we'll avoid doing any kind
+	// for the sake of simplicity we'll avoid doing any kind
 	// of parsing here. Since those labels are set by the controller
 	// it self. We'll expect the same values back.
 	return s == "true"


### PR DESCRIPTION
This PR fixes some typos in code comments:

- `parametes` -> `parameters`
- `recnociliation` -> `reconciliation`
- `instanciator` -> `instantiator`
- `Staticc` -> `Static`
- `exauhst` -> `exhaust`
- `deinitions` -> `definitions`
- `emualting` -> `emulating`
- `unmashal` -> `unmarshal`
- `posible` -> `possible`
- `simplicy` -> `simplicity`

Due to the minor nature of the changes, I didn't open a GitHub issue.
