### PR TITLE
feat: set default version values and add version label tests

### DIFF
--- a/pkg/version.go
+++ b/pkg/version.go
@@ -16,9 +16,9 @@ package pkg
 // These variables are populated by the go compiler using -ldflags
 var (
 	// Version is the version of the kro binary.
-	Version string // -X github.com/your/repo/pkg.Version=$(VERSION)
+	Version string = "unknown" // -X github.com/your/repo/pkg.Version=$(VERSION)
 	// GitCommit is the git commit that was compiled.
-	GitCommit string // -X github.com/your/repo/pkg.GitCommit=$(GIT_COMMIT)
+	GitCommit string = "unknown" // -X github.com/your/repo/pkg.GitCommit=$(GIT_COMMIT)
 	// BuildDate is the date that the kro binary was built.
-	BuildDate string // -X github.com/your/repo/pkg.BuildDate=$(BUILD_DATE)
+	BuildDate string = "unknown" // -X github.com/your/repo/pkg.BuildDate=$(BUILD_DATE)
 )

--- a/test/integration/suites/deploymentservice/suite_test.go
+++ b/test/integration/suites/deploymentservice/suite_test.go
@@ -30,7 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	krov1alpha1 "github.com/kro-run/kro/api/v1alpha1"
+	"github.com/kro-run/kro/pkg"
 	ctrlinstance "github.com/kro-run/kro/pkg/controller/instance"
+	"github.com/kro-run/kro/pkg/metadata"
 	"github.com/kro-run/kro/test/integration/environment"
 )
 
@@ -161,6 +163,8 @@ var _ = Describe("DeploymentService", func() {
 			g.Expect(service.Spec.Ports).To(HaveLen(1))
 			g.Expect(service.Spec.Ports[0].Port).To(Equal(int32(8080)))
 			g.Expect(service.Spec.Ports[0].TargetPort.IntVal).To(Equal(int32(8080)))
+			g.Expect(service.ObjectMeta.Labels).To(HaveKeyWithValue(metadata.OwnedLabel, "true"))
+			g.Expect(service.ObjectMeta.Labels).To(HaveKeyWithValue(metadata.KROVersionLabel, pkg.Version))
 		}, 20*time.Second, time.Second).Should(Succeed())
 
 		// Verify instance status is updated


### PR DESCRIPTION
Set default "unknown" values for Version, GitCommit, and BuildDate
variables to ensure proper functionality when built without ldflags.