### PR TITLE
chore: replace hardcoded versions with ${VERSION} placeholders

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kro
 description: A Helm chart for kro
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: ${VERSION}
+appVersion: ${VERSION}
 home: https://kro.run/

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,7 +11,7 @@ image:
   # The location of the container image repository
   repository: ghcr.io/kro-run/kro/controller
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.2"
+  tag: ${VERSION}
   # Ignores the repository and tag settings and uses the controllers ko entrypoint.
   ko: false
   # Image pull policy (IfNotPresent: pull the image only if it is not present locally)


### PR DESCRIPTION
The current release automation substitue the correct version values during the build/release process.