### PR TITLE
Add CEL standard library to DefaultEnvironment

### DIFF
--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -57,6 +57,7 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 		// default stdlibs
 		ext.Lists(),
 		ext.Strings(),
+		cel.StdLib(),
 	}
 
 	for _, name := range opts.resourceIDs {


### PR DESCRIPTION
Fixes https://github.com/kro-run/kro/issues/80

Add `cel.StdLib()` to DefaultEnvironment to include standard type
conversion functions like `string()` and `int()` in our CEL environment