### PR TITLE
chore: fix typos in documentation

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@
 
 <!-- template begins here-->
 
-This governance document explains how the Kube Resource Orchestratory project is run.
+This governance document explains how the Kube Resource Orchestrator project is run.
 
 - [Kube Resource Orchestrator Project Governance](#kube-resource-orchestrator-project-governance)
   - [Values](#values)

--- a/examples/aws/ack-controller/README.md
+++ b/examples/aws/ack-controller/README.md
@@ -1,7 +1,7 @@
 # Steps to deploy ack-controllers to cluster
 
 ## Deploying Controllers
-Conbined ResourseGroup for ACK Controllers
+Combined ResourseGroup for ACK Controllers
 - IAM
 - EC2
 - EKS

--- a/examples/aws/webstack/Readme.md
+++ b/examples/aws/webstack/Readme.md
@@ -3,7 +3,7 @@
 This example creates a ResourceGraphDefinition called `WebStack` comprised of
 three other RGs: `WebApp`, `S3Bucket`, and `PodIdentity`
 
-![Netsted RGD Instance](../../../images/architecture-diagrams/kro-WebStack.png)
+![Nested RGD Instance](../../../images/architecture-diagrams/kro-WebStack.png)
 _Figure 1: Nested RGD Example_
 
 ### Create ResourceGraphDefinitions

--- a/test/README.md
+++ b/test/README.md
@@ -19,7 +19,7 @@ deployed in production clusters.
 2. Focus on kro's logic, not on other controllers or Kubernetes components. e.g
    avoid testing native controllers, ACK or Karpenter's behaviour...
 3. Prioritize integration tests, validate with end to end tests.
-4. Maintain seperation of concerns, controller logic, integration tests, and e2e
+4. Maintain separation of concerns, controller logic, integration tests, and e2e
    tests
 5. Ensure readability: similar to the codebase, tests should be easy to read,
    understand and maintain.
@@ -87,7 +87,7 @@ should:
 12. Delete the `ResourceGraphDefinition` custom resource
 13. Verify that the corresponding CRD is removed from the cluster
 
-### Addional scenarios
+### Additional scenarios
 
 1. Cross namespace resource management
 2. Scaling testing: Create a large number of ResourceGraphDefinitions and ResourceGraphDefinition


### PR DESCRIPTION
This PR fixes some typos in documentation:

- `Orchestratory` -> `Orchestrator`
- `Conbined` -> `Combined`
- `Netsted` -> `Nested`
- `seperation` -> `separation`
- `Addional` -> `Additional`

Due to the minor nature of the changes, I didn't open a GitHub issue.