### PR TITLE
chore: increase test coverage of `pkg/metadata/labels.go` to 100%

### DIFF
--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -16,10 +16,11 @@ package metadata
 import (
 	"testing"
 
-	"github.com/kro-run/kro/pkg"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kro-run/kro/pkg"
 )
 
 // mockObject is a simple implementation of metav1.Object for testing

--- a/pkg/metadata/labels_test.go
+++ b/pkg/metadata/labels_test.go
@@ -16,8 +16,10 @@ package metadata
 import (
 	"testing"
 
+	"github.com/kro-run/kro/pkg"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // mockObject is a simple implementation of metav1.Object for testing
@@ -119,25 +121,28 @@ func TestSetKROUnowned(t *testing.T) {
 func TestGenericLabeler(t *testing.T) {
 	t.Run("ApplyLabels", func(t *testing.T) {
 		cases := []struct {
-			name     string
-			labeler  GenericLabeler
-			expected map[string]string
+			name         string
+			labeler      GenericLabeler
+			objectLabels map[string]string
+			expected     map[string]string
 		}{
 			{
-				name:     "Apply labels to empty object",
-				labeler:  GenericLabeler{"key1": "value1", "key2": "value2"},
-				expected: map[string]string{"key1": "value1", "key2": "value2"},
+				name:         "Apply labels to empty object",
+				labeler:      GenericLabeler{"key1": "value1", "key2": "value2"},
+				objectLabels: nil,
+				expected:     map[string]string{"key1": "value1", "key2": "value2"},
 			},
 			{
-				name:     "Apply labels to object with existing labels",
-				labeler:  GenericLabeler{"key2": "newvalue2", "key3": "value3"},
-				expected: map[string]string{"key1": "value1", "key2": "newvalue2", "key3": "value3"},
+				name:         "Apply labels to object with existing labels",
+				labeler:      GenericLabeler{"key2": "newvalue2", "key3": "value3"},
+				objectLabels: map[string]string{"key1": "value1", "key2": "value2"},
+				expected:     map[string]string{"key1": "value1", "key2": "newvalue2", "key3": "value3"},
 			},
 		}
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"key1": "value1"}}}
+				obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Labels: tc.objectLabels}}
 				tc.labeler.ApplyLabels(obj)
 				assert.Equal(t, tc.expected, obj.Labels)
 			})
@@ -179,5 +184,40 @@ func TestGenericLabeler(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+func TestNewResourceGraphDefinitionLabeler(t *testing.T) {
+	t.Run("NewResourceGraphDefinitionLabeler", func(t *testing.T) {
+		name := "rgd-name"
+		uid := types.UID("rgd-uid")
+		obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid}}
+		labeler := NewResourceGraphDefinitionLabeler(obj)
+		assert.Equal(t, GenericLabeler{
+			ResourceGraphDefinitionNameLabel: name,
+			ResourceGraphDefinitionIDLabel:   string(uid),
+		}, labeler)
+	})
+}
+
+func TestNewInstanceLabeler(t *testing.T) {
+	t.Run("NewInstanceLabeler", func(t *testing.T) {
+		name := "instance-name"
+		namespace := "instance-namespace"
+		uid := types.UID("instance-uid")
+		obj := &mockObject{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: uid}}
+		labeler := NewInstanceLabeler(obj)
+		assert.Equal(t, GenericLabeler{
+			InstanceLabel:          name,
+			InstanceNamespaceLabel: namespace,
+			InstanceIDLabel:        string(uid),
+		}, labeler)
+	})
+}
+
+func TestNewKROMetaLabeler(t *testing.T) {
+	t.Run("NewKROMetaLabeler", func(t *testing.T) {
+		labeler := NewKROMetaLabeler()
+		assert.Equal(t, GenericLabeler{OwnedLabel: "true", KROVersionLabel: pkg.Version}, labeler)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds 3 new unit test functions and fix a test case structure of `pkg/metadata/labels.go`, reaching 100% test coverage.

## Evidence
<details><summary>before the commit</summary>

```
% go test -coverprofile=coverage.out ./... > /dev/null                           
% go tool cover -func=coverage.out | grep labels.go  
github.com/kro-run/kro/pkg/metadata/labels.go:48:						IsKROOwned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:54:						SetKROOwned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:59:						SetKROUnowned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:82:						Labels							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:87:						ApplyLabels						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:95:						Merge							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:107:						Copy							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:117:						NewResourceGraphDefinitionLabeler			0.0%
github.com/kro-run/kro/pkg/metadata/labels.go:127:						NewInstanceLabeler					0.0%
github.com/kro-run/kro/pkg/metadata/labels.go:137:						NewKROMetaLabeler					0.0%
github.com/kro-run/kro/pkg/metadata/labels.go:144:						booleanFromString					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:151:						stringFromBoolean					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:159:						setLabel						80.0%
```

</details>

<details><summary>after the commit</summary>

```
% go test -coverprofile=coverage.out ./... > /dev/null                           
% go tool cover -func=coverage.out | grep labels.go                            
github.com/kro-run/kro/pkg/metadata/labels.go:48:						IsKROOwned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:54:						SetKROOwned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:59:						SetKROUnowned						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:82:						Labels							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:87:						ApplyLabels						100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:95:						Merge							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:107:						Copy							100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:117:						NewResourceGraphDefinitionLabeler			100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:127:						NewInstanceLabeler					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:137:						NewKROMetaLabeler					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:144:						booleanFromString					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:151:						stringFromBoolean					100.0%
github.com/kro-run/kro/pkg/metadata/labels.go:159:						setLabel						100.0%
```

</details>

## Additional Info

Due to the minor nature of the changes, I didn't open a GitHub issue.