### PR TITLE
chore: increase test coverage `pkg/graph/validation.go` to 100%

### DIFF
--- a/pkg/graph/validation_test.go
+++ b/pkg/graph/validation_test.go
@@ -250,3 +250,49 @@ func TestValidateKubernetesVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateResourceGraphDefinitionNamingConventions(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		kind       string
+		wantErr    bool
+	}{
+		{
+			name:       "Valid naming conventions",
+			resourceID: "validResourceID",
+			kind:       "ValidKindName",
+			wantErr:    false,
+		},
+		{
+			name:       "Invalid kind name",
+			resourceID: "validResourceID",
+			kind:       "invalidKindName",
+			wantErr:    true,
+		},
+		{
+			name:       "Invalid resource ID",
+			resourceID: "invalid_ResourceID",
+			kind:       "ValidKindName",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rgd := &v1alpha1.ResourceGraphDefinition{
+				Spec: v1alpha1.ResourceGraphDefinitionSpec{
+					Resources: []*v1alpha1.Resource{
+						{ID: tt.resourceID},
+					},
+					Schema: &v1alpha1.Schema{
+						Kind: tt.kind,
+					},
+				},
+			}
+			if err := validateResourceGraphDefinitionNamingConventions(rgd); (err != nil) != tt.wantErr {
+				t.Errorf("validateResourceGraphDefinitionNamingConventions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds one new unit test function, reaching 100% test coverage.

The current coverage of `validateResourceGraphDefinitionNamingConventions` is 83.3%, but there is no test function for that. The coverage was high because it was being called by another function (`NewResourceGraphDefinition`) in builder.go .

## Evidence
<details><summary>before the commit</summary>

```
% go test -coverprofile=coverage.out ./... > /dev/null                           
% go tool cover -func=coverage.out | grep graph/validation
github.com/kro-run/kro/pkg/graph/validation.go:68:						isValidResourceID					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:73:						isValidKindName						100.0%
github.com/kro-run/kro/pkg/graph/validation.go:78:						isKROReservedWord					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:89:						validateResourceGraphDefinitionNamingConventions	83.3%
github.com/kro-run/kro/pkg/graph/validation.go:108:						validateResourceIDs					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:132:						validateKubernetesObjectStructure			100.0%
github.com/kro-run/kro/pkg/graph/validation.go:165:						validateKubernetesVersion				100.0%
```

</details>

<details><summary>after the commit</summary>

```
% go test -coverprofile=coverage.out ./... > /dev/null                           
% go tool cover -func=coverage.out | grep graph/validation
github.com/kro-run/kro/pkg/graph/validation.go:68:						isValidResourceID					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:73:						isValidKindName						100.0%
github.com/kro-run/kro/pkg/graph/validation.go:78:						isKROReservedWord					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:89:						validateResourceGraphDefinitionNamingConventions	100.0%
github.com/kro-run/kro/pkg/graph/validation.go:108:						validateResourceIDs					100.0%
github.com/kro-run/kro/pkg/graph/validation.go:132:						validateKubernetesObjectStructure			100.0%
github.com/kro-run/kro/pkg/graph/validation.go:165:						validateKubernetesVersion				100.0%
```

</details>

## Additional Info

Due to the minor nature of the changes, I didn't open a GitHub issue.