### PR TITLE
chore: fix imports according to standard ordering in Go

### DIFF
--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -15,12 +15,13 @@ package client
 import (
 	"fmt"
 
-	"github.com/kro-run/kro/pkg"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrlrtconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/kro-run/kro/pkg"
 )
 
 // Set provides a unified interface for different Kubernetes clients

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
+
 	"github.com/kro-run/kro/api/v1alpha1"
 	"github.com/kro-run/kro/pkg/metadata"
 )


### PR DESCRIPTION
## Description
This PR fix imports order according to standard ordering in Go.

The following command was performed to find and fix the problems:
```
goimports -w -local github.com/kro-run/kro ./pkg
```
## Additional Info
Due to the minor nature of the changes, I didn't open a GitHub issue.