### PR TITLE
docs: fix broken code of conduct link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -113,7 +113,7 @@ accused of a CoC violation.
 
 ## Code of Conduct
 
-[Code of Conduct](./code-of-conduct.md)
+[Code of Conduct](./CODE_OF_CONDUCT.md)
 violations by community members will be discussed and resolved
 on the [private Maintainer mailing list](TODO). 
 


### PR DESCRIPTION
Fix broken code of conduct link in `GOVERNANCE.md`