### PR TITLE
chore: add test case to TestGraphBuilder_Validation

### DIFF
--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -83,6 +83,20 @@ func TestGraphBuilder_Validation(t *testing.T) {
 			errMsg:  "naming convention violation",
 		},
 		{
+			name: "invalid KRO kind name",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"invalidKind", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+			},
+			wantErr: true,
+			errMsg:  "is not a valid KRO kind name",
+		},
+		{
 			name: "resource without a valid GVK",
 			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
 				generator.WithSchema(


### PR DESCRIPTION
## Description

This PR adds a new test case to TestGraphBuilder_Validation to check if the proper the error is returned when `RGD.Spec.Schema.Kind` is invalid.

## Additional Info

Due to the minor nature of the changes, I didn't open a GitHub issue.