### PR TITLE
chore: replace deprecated package `io/ioutil` by `io`

### DIFF
--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -14,7 +14,7 @@ package dynamiccontroller
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -37,7 +37,7 @@ import (
 func noopLogger() logr.Logger {
 	opts := zap.Options{
 		// Write to dev/null
-		DestWriter: ioutil.Discard,
+		DestWriter: io.Discard,
 	}
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	return logger


### PR DESCRIPTION
## Description

This PR replaces the deprecated package `io/ioutil` by `io` (see [details](https://cs.opensource.google/go/go/+/master:src/io/ioutil/ioutil.go;l=7-10?q=ioutil&ss=go%2Fgo)).

## Additional Info

Due to the minor nature of the changes, I didn't open a GitHub issue.

