### PR TITLE
Adding kubeconfig env. var. to kind-deploy make step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 export BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 export RELEASE_VERSION ?= dev-$(GIT_COMMIT)
 OCI_REPO ?= ghcr.io/kro-run/kro
-
+KIND_KUBECONFIG_PATH ?= /tmp/kind-config
 HELM_IMAGE ?= ${OCI_REPO}
 KO_DOCKER_REPO ?= ${OCI_REPO}/kro
 
@@ -236,8 +236,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy-kind
 deploy-kind: export KO_DOCKER_REPO=kind.local
+deploy-kind: export KUBECONFIG=${KIND_KUBECONFIG_PATH}
 deploy-kind: ko
-	export KUBECONFIG=/tmp/kind-config
 	$(KIND) delete clusters ${KIND_CLUSTER_NAME} || true
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KUBECTL) --context kind-$(KIND_CLUSTER_NAME) create namespace kro-system

--- a/Makefile
+++ b/Makefile
@@ -237,11 +237,12 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy-kind
 deploy-kind: export KO_DOCKER_REPO=kind.local
 deploy-kind: ko
+	export KUBECONFIG=/tmp/kind-config
 	$(KIND) delete clusters ${KIND_CLUSTER_NAME} || true
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KUBECTL) --context kind-$(KIND_CLUSTER_NAME) create namespace kro-system
 	make install
-	# This generates deployment with ko://... used in image. 
+	# This generates deployment with ko://... used in image.
 	# ko then intercepts it builds image, pushes to kind node, replaces the image in deployment and applies it
 	helm template kro ./helm --namespace kro-system --set image.pullPolicy=Never --set image.ko=true | $(KO) apply -f -
 	kubectl wait --for=condition=ready --timeout=1m pod -n kro-system -l app.kubernetes.io/component=controller

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy-kind: export KO_DOCKER_REPO=kind.local
 deploy-kind: export KUBECONFIG=${KIND_KUBECONFIG_PATH}
 deploy-kind: ko
+	rm -f ${KIND_KUBECONFIG_PATH} # remove kubeconfig on each run
 	$(KIND) delete clusters ${KIND_CLUSTER_NAME} || true
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KUBECTL) --context kind-$(KIND_CLUSTER_NAME) create namespace kro-system


### PR DESCRIPTION
## Background 

`kind` cli is causing problems while working with default kubeconfig file(~/.kube/config) in the host machine. Setting `KUBECONFIG` env. var. solves the issue. 