### PR TITLE
chore: remove unnecessary logging during resource graph definition reconciliation

### DIFF
--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -90,12 +90,10 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(ctx context.Context, resou
 	ctx = log.IntoContext(ctx, rlog)
 
 	if !resourcegraphdefinition.DeletionTimestamp.IsZero() {
-		rlog.V(1).Info("ResourceGraphDefinition is being deleted")
 		if err := r.cleanupResourceGraphDefinition(ctx, resourcegraphdefinition); err != nil {
 			return ctrl.Result{}, err
 		}
 
-		rlog.V(1).Info("Setting resourcegraphdefinition as unmanaged")
 		if err := r.setUnmanaged(ctx, resourcegraphdefinition); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -103,15 +101,12 @@ func (r *ResourceGraphDefinitionReconciler) Reconcile(ctx context.Context, resou
 		return ctrl.Result{}, nil
 	}
 
-	rlog.V(1).Info("Setting resource graph definition as managed")
 	if err := r.setManaged(ctx, resourcegraphdefinition); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	rlog.V(1).Info("Syncing resourcegraphdefinition")
 	topologicalOrder, resourcesInformation, reconcileErr := r.reconcileResourceGraphDefinition(ctx, resourcegraphdefinition)
 
-	rlog.V(1).Info("Setting resourcegraphdefinition status")
 	if err := r.setResourceGraphDefinitionStatus(ctx, resourcegraphdefinition, topologicalOrder, resourcesInformation, reconcileErr); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Bugged me a bit that there are double logging
example:
![image](https://github.com/user-attachments/assets/707e5a9e-14b3-4001-8ee8-8051457a307c)

Each other log call is done in their respective method
https://github.com/kro-run/kro/blob/0b438927cf198fd02f9a22d309d4ebc6490795b7/pkg/controller/resourcegraphdefinition/controller_cleanup.go#L33-L35
https://github.com/kro-run/kro/blob/0b438927cf198fd02f9a22d309d4ebc6490795b7/pkg/controller/resourcegraphdefinition/controller_status.go#L161-L163
https://github.com/kro-run/kro/blob/0b438927cf198fd02f9a22d309d4ebc6490795b7/pkg/controller/resourcegraphdefinition/controller_status.go#L145-L147
https://github.com/kro-run/kro/blob/0b438927cf198fd02f9a22d309d4ebc6490795b7/pkg/controller/resourcegraphdefinition/controller_reconcile.go#L36-L40
https://github.com/kro-run/kro/blob/0b438927cf198fd02f9a22d309d4ebc6490795b7/pkg/controller/resourcegraphdefinition/controller_status.go#L86-L94