### PR TITLE
chore: add test case to TestLoadPredefinedTypes

### DIFF
--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -402,7 +402,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 				},
 			},
 			want: map[string]extv1.JSONSchemaProps{
-				"Person": extv1.JSONSchemaProps{
+				"Person": {
 					Type: "object",
 					Properties: map[string]extv1.JSONSchemaProps{
 						"name": {Type: "string"},
@@ -416,7 +416,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 						},
 					},
 				},
-				"Company": extv1.JSONSchemaProps{
+				"Company": {
 					Type: "object",
 					Properties: map[string]extv1.JSONSchemaProps{
 						"name": {Type: "string"},

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -379,77 +379,80 @@ func TestBuildOpenAPISchema(t *testing.T) {
 func TestLoadPreDefinedTypes(t *testing.T) {
 	transformer := newTransformer()
 
-	preDefinedTypes := map[string]interface{}{
-		"Person": map[string]interface{}{
-			"name": "string",
-			"age":  "integer",
-			"address": map[string]interface{}{
-				"street": "string",
-				"city":   "string",
-			},
-		},
-		"Company": map[string]interface{}{
-			"name":      "string",
-			"employees": "[]string",
-		},
-	}
-
-	err := transformer.loadPreDefinedTypes(preDefinedTypes)
-	if err != nil {
-		t.Fatalf("LoadPreDefinedTypes() error = %v", err)
-	}
-
-	if len(transformer.preDefinedTypes) != 2 {
-		t.Errorf("LoadPreDefinedTypes() loaded %d types, want 2", len(transformer.preDefinedTypes))
-	}
-
-	// Check Person type
-	personType, ok := transformer.preDefinedTypes["Person"]
-	if !ok {
-		t.Errorf("LoadPreDefinedTypes() did not load 'Person' type")
-	}
-
-	expectedPersonType := extv1.JSONSchemaProps{
-		Type: "object",
-		Properties: map[string]extv1.JSONSchemaProps{
-			"name": {Type: "string"},
-			"age":  {Type: "integer"},
-			"address": {
-				Type: "object",
-				Properties: map[string]extv1.JSONSchemaProps{
-					"street": {Type: "string"},
-					"city":   {Type: "string"},
+	tests := []struct {
+		name    string
+		obj     map[string]interface{}
+		want    map[string]extv1.JSONSchemaProps
+		wantErr bool
+	}{
+		{
+			name: "Valid types",
+			obj: map[string]interface{}{
+				"Person": map[string]interface{}{
+					"name": "string",
+					"age":  "integer",
+					"address": map[string]interface{}{
+						"street": "string",
+						"city":   "string",
+					},
+				},
+				"Company": map[string]interface{}{
+					"name":      "string",
+					"employees": "[]string",
 				},
 			},
-		},
-	}
-
-	if !reflect.DeepEqual(personType, expectedPersonType) {
-		t.Errorf("LoadPreDefinedTypes() 'Person' type = %v, want %v", personType, expectedPersonType)
-	}
-
-	// Check Company type
-	companyType, ok := transformer.preDefinedTypes["Company"]
-	if !ok {
-		t.Errorf("LoadPreDefinedTypes() did not load 'Company' type")
-	}
-
-	expectedCompanyType := extv1.JSONSchemaProps{
-		Type: "object",
-		Properties: map[string]extv1.JSONSchemaProps{
-			"name": {Type: "string"},
-			"employees": {
-				Type: "array",
-				Items: &extv1.JSONSchemaPropsOrArray{
-					Schema: &extv1.JSONSchemaProps{
-						Type: "string",
+			want: map[string]extv1.JSONSchemaProps{
+				"Person": extv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]extv1.JSONSchemaProps{
+						"name": {Type: "string"},
+						"age":  {Type: "integer"},
+						"address": {
+							Type: "object",
+							Properties: map[string]extv1.JSONSchemaProps{
+								"street": {Type: "string"},
+								"city":   {Type: "string"},
+							},
+						},
+					},
+				},
+				"Company": extv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]extv1.JSONSchemaProps{
+						"name": {Type: "string"},
+						"employees": {
+							Type: "array",
+							Items: &extv1.JSONSchemaPropsOrArray{
+								Schema: &extv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
 					},
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid type",
+			obj: map[string]interface{}{
+				"invalid": 123,
+			},
+			want:    map[string]extv1.JSONSchemaProps{},
+			wantErr: true,
 		},
 	}
 
-	if !reflect.DeepEqual(companyType, expectedCompanyType) {
-		t.Errorf("LoadPreDefinedTypes() 'Company' type = %v, want %v", companyType, expectedCompanyType)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := transformer.loadPreDefinedTypes(tt.obj)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("LoadPreDefinedTypes() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(transformer.preDefinedTypes, tt.want) {
+				t.Errorf("LoadPreDefinedTypes() = %+v, want %+v", transformer.preDefinedTypes, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

This PR adds a new negative test case to TestLoadPredefinedTypes, in order to check the error return. It was needed to add a test cases array to be able to declare multiple test cases.

## Additional Info
- Due to the minor nature of the changes, I didn't open a GitHub issue.
- The same change was proposed in [PR #447](https://github.com/kro-run/kro/pull/447), but for some unknown reason, the LINT workflow was not passing.