### PR TITLE
Do not store loggers in controller stucts

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -166,7 +166,6 @@ func main() {
 	}
 
 	rgd := resourcegraphdefinitionctrl.NewResourceGraphDefinitionReconciler(
-		mgr.GetClient(),
 		set,
 		allowCRDDeletion,
 		dc,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -24,12 +24,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlrtcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	xv1alpha1 "github.com/kro-run/kro/api/v1alpha1"
 	kroclient "github.com/kro-run/kro/pkg/client"
@@ -145,6 +142,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Logger: rootLogger,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -167,26 +165,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler := resourcegraphdefinitionctrl.NewResourceGraphDefinitionReconciler(
-		rootLogger,
+	rgd := resourcegraphdefinitionctrl.NewResourceGraphDefinitionReconciler(
 		mgr.GetClient(),
 		set,
 		allowCRDDeletion,
 		dc,
 		resourceGraphDefinitionGraphBuilder,
+		resourceGraphDefinitionConcurrentReconciles,
 	)
-	err = ctrl.NewControllerManagedBy(
-		mgr,
-	).For(
-		&xv1alpha1.ResourceGraphDefinition{},
-	).WithEventFilter(
-		predicate.GenerationChangedPredicate{},
-	).WithOptions(
-		ctrlrtcontroller.Options{
-			MaxConcurrentReconciles: resourceGraphDefinitionConcurrentReconciles,
-		},
-	).Complete(reconcile.AsReconciler[*xv1alpha1.ResourceGraphDefinition](mgr.GetClient(), reconciler))
-	if err != nil {
+	if err := rgd.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ResourceGraphDefinition")
 		os.Exit(1)
 	}

--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	logr "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -51,7 +51,6 @@ type CRDClient interface {
 // CRDWrapper provides a simplified interface for CRD operations
 type CRDWrapper struct {
 	client       apiextensionsv1.CustomResourceDefinitionInterface
-	log          logr.Logger
 	pollInterval time.Duration
 	timeout      time.Duration
 }
@@ -59,7 +58,6 @@ type CRDWrapper struct {
 // CRDWrapperConfig contains configuration for the CRD wrapper
 type CRDWrapperConfig struct {
 	Client       *apiextensionsv1.ApiextensionsV1Client
-	Log          logr.Logger
 	PollInterval time.Duration
 	Timeout      time.Duration
 }
@@ -83,7 +81,6 @@ func newCRDWrapper(cfg CRDWrapperConfig) *CRDWrapper {
 
 	return &CRDWrapper{
 		client:       cfg.Client.CustomResourceDefinitions(),
-		log:          cfg.Log.WithName("crd-wrapper"),
 		pollInterval: cfg.PollInterval,
 		timeout:      cfg.Timeout,
 	}
@@ -95,18 +92,19 @@ func newCRDWrapper(cfg CRDWrapperConfig) *CRDWrapper {
 // The caller is responsible for ensuring the CRD, isn't introducing
 // breaking changes.
 func (w *CRDWrapper) Ensure(ctx context.Context, crd v1.CustomResourceDefinition) error {
+	log := logr.FromContext(ctx)
 	_, err := w.Get(ctx, crd.Name)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to check for existing CRD: %w", err)
 		}
 
-		w.log.Info("Creating CRD", "name", crd.Name)
+		log.Info("Creating CRD", "name", crd.Name)
 		if err := w.create(ctx, crd); err != nil {
 			return fmt.Errorf("failed to create CRD: %w", err)
 		}
 	} else {
-		w.log.Info("Updating existing CRD", "name", crd.Name)
+		log.Info("Updating existing CRD", "name", crd.Name)
 		if err := w.patch(ctx, crd); err != nil {
 			return fmt.Errorf("failed to patch CRD: %w", err)
 		}
@@ -143,7 +141,8 @@ func (w *CRDWrapper) patch(ctx context.Context, newCRD v1.CustomResourceDefiniti
 
 // Delete removes a CRD if it exists
 func (w *CRDWrapper) Delete(ctx context.Context, name string) error {
-	w.log.Info("Deleting CRD", "name", name)
+	log := logr.FromContext(ctx)
+	log.Info("Deleting CRD", "name", name)
 
 	err := w.client.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -154,7 +153,8 @@ func (w *CRDWrapper) Delete(ctx context.Context, name string) error {
 
 // waitForReady waits for a CRD to become ready
 func (w *CRDWrapper) waitForReady(ctx context.Context, name string) error {
-	w.log.Info("Waiting for CRD to become ready", "name", name)
+	log := logr.FromContext(ctx)
+	log.Info("Waiting for CRD to become ready", "name", name)
 
 	return wait.PollUntilContextTimeout(ctx, w.pollInterval, w.timeout, true,
 		func(ctx context.Context) (bool, error) {

--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -117,9 +117,9 @@ func (c *Set) RESTConfig() *rest.Config {
 }
 
 // CRD returns a new CRDWrapper instance
-func (s *Set) CRD(cfg CRDWrapperConfig) *CRDWrapper {
+func (c *Set) CRD(cfg CRDWrapperConfig) *CRDWrapper {
 	if cfg.Client == nil {
-		cfg.Client = s.apiExtensionsV1
+		cfg.Client = c.apiExtensionsV1
 	}
 
 	return newCRDWrapper(cfg)

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -15,17 +15,19 @@ package resourcegraphdefinition
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
-	"github.com/kro-run/kro/api/v1alpha1"
-	kroclient "github.com/kro-run/kro/pkg/client"
-	"github.com/kro-run/kro/pkg/dynamiccontroller"
-	"github.com/kro-run/kro/pkg/graph"
-	"github.com/kro-run/kro/pkg/metadata"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlrtcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kro-run/kro/api/v1alpha1"
+	kroclient "github.com/kro-run/kro/pkg/client"
+	"github.com/kro-run/kro/pkg/dynamiccontroller"
+	"github.com/kro-run/kro/pkg/graph"
+	"github.com/kro-run/kro/pkg/metadata"
 )
 
 //+kubebuilder:rbac:groups=kro.run,resources=resourcegraphdefinitions,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -47,7 +47,7 @@ type ResourceGraphDefinitionReconciler struct {
 	metadataLabeler         metadata.Labeler
 	rgBuilder               *graph.Builder
 	dynamicController       *dynamiccontroller.DynamicController
-	MaxConcurrentReconciles int
+	maxConcurrentReconciles int
 }
 
 func NewResourceGraphDefinitionReconciler(
@@ -55,7 +55,7 @@ func NewResourceGraphDefinitionReconciler(
 	allowCRDDeletion bool,
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
-	MaxConcurrentReconciles int,
+	maxConcurrentReconciles int,
 ) *ResourceGraphDefinitionReconciler {
 	crdWrapper := clientSet.CRD(kroclient.CRDWrapperConfig{})
 
@@ -66,7 +66,7 @@ func NewResourceGraphDefinitionReconciler(
 		dynamicController:       dynamicController,
 		metadataLabeler:         metadata.NewKROMetaLabeler(),
 		rgBuilder:               builder,
-		MaxConcurrentReconciles: MaxConcurrentReconciles,
+		maxConcurrentReconciles: maxConcurrentReconciles,
 	}
 }
 
@@ -94,7 +94,7 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 		WithOptions(
 			ctrlrtcontroller.Options{
 				LogConstructor:          logConstructor,
-				MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+				MaxConcurrentReconciles: r.maxConcurrentReconciles,
 			},
 		).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -15,12 +15,10 @@ package resourcegraphdefinition
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlrtcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -37,79 +35,84 @@ import (
 
 // ResourceGraphDefinitionReconciler reconciles a ResourceGraphDefinition object
 type ResourceGraphDefinitionReconciler struct {
-	log        logr.Logger
-	rootLogger logr.Logger
-
 	allowCRDDeletion bool
 
 	client.Client
 	clientSet  *kroclient.Set
 	crdManager kroclient.CRDClient
 
-	metadataLabeler   metadata.Labeler
-	rgBuilder         *graph.Builder
-	dynamicController *dynamiccontroller.DynamicController
+	metadataLabeler         metadata.Labeler
+	rgBuilder               *graph.Builder
+	dynamicController       *dynamiccontroller.DynamicController
+	MaxConcurrentReconciles int
 }
 
 func NewResourceGraphDefinitionReconciler(
-	log logr.Logger,
 	mgrClient client.Client,
 	clientSet *kroclient.Set,
 	allowCRDDeletion bool,
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
+	MaxConcurrentReconciles int,
 ) *ResourceGraphDefinitionReconciler {
-	crdWrapper := clientSet.CRD(kroclient.CRDWrapperConfig{
-		Log: log,
-	})
-	rgLogger := log.WithName("controller.resourceGraphDefinition")
+	crdWrapper := clientSet.CRD(kroclient.CRDWrapperConfig{})
 
 	return &ResourceGraphDefinitionReconciler{
-		rootLogger:        log,
-		log:               rgLogger,
-		clientSet:         clientSet,
-		Client:            mgrClient,
-		allowCRDDeletion:  allowCRDDeletion,
-		crdManager:        crdWrapper,
-		dynamicController: dynamicController,
-		metadataLabeler:   metadata.NewKROMetaLabeler(),
-		rgBuilder:         builder,
+		clientSet:               clientSet,
+		Client:                  mgrClient,
+		allowCRDDeletion:        allowCRDDeletion,
+		crdManager:              crdWrapper,
+		dynamicController:       dynamicController,
+		metadataLabeler:         metadata.NewKROMetaLabeler(),
+		rgBuilder:               builder,
+		MaxConcurrentReconciles: MaxConcurrentReconciles,
 	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	logConstructor := func(req *reconcile.Request) logr.Logger {
+		log := mgr.GetLogger().WithName("rgd-controller").WithValues(
+			"controller", "ResourceGraphDefinition",
+			"controllerGroup", v1alpha1.GroupVersion.Group,
+			"controllerKind", "ResourceGraphDefinition",
+		)
+		if req != nil {
+			log = log.WithValues("name", req.Name)
+		}
+		return log
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("ResourceGraphDefinition").
 		For(&v1alpha1.ResourceGraphDefinition{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(
+			ctrlrtcontroller.Options{
+				LogConstructor:          logConstructor,
+				MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			},
+		).
 		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))
 }
 
-func (r *ResourceGraphDefinitionReconciler) Reconcile(ctx context.Context, resourcegraphdefinition *v1alpha1.ResourceGraphDefinition) (ctrl.Result, error) {
-	rlog := r.log.WithValues("resourcegraphdefinition", types.NamespacedName{Namespace: resourcegraphdefinition.Namespace, Name: resourcegraphdefinition.Name})
-	ctx = log.IntoContext(ctx, rlog)
-
-	if !resourcegraphdefinition.DeletionTimestamp.IsZero() {
-		if err := r.cleanupResourceGraphDefinition(ctx, resourcegraphdefinition); err != nil {
+func (r *ResourceGraphDefinitionReconciler) Reconcile(ctx context.Context, o *v1alpha1.ResourceGraphDefinition) (ctrl.Result, error) {
+	if !o.DeletionTimestamp.IsZero() {
+		if err := r.cleanupResourceGraphDefinition(ctx, o); err != nil {
 			return ctrl.Result{}, err
 		}
-
-		if err := r.setUnmanaged(ctx, resourcegraphdefinition); err != nil {
+		if err := r.setUnmanaged(ctx, o); err != nil {
 			return ctrl.Result{}, err
 		}
-
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.setManaged(ctx, resourcegraphdefinition); err != nil {
+	if err := r.setManaged(ctx, o); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	topologicalOrder, resourcesInformation, reconcileErr := r.reconcileResourceGraphDefinition(ctx, resourcegraphdefinition)
+	topologicalOrder, resourcesInformation, reconcileErr := r.reconcileResourceGraphDefinition(ctx, o)
 
-	if err := r.setResourceGraphDefinitionStatus(ctx, resourcegraphdefinition, topologicalOrder, resourcesInformation, reconcileErr); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{},
+		r.setResourceGraphDefinitionStatus(ctx, o, topologicalOrder, resourcesInformation, reconcileErr)
 }

--- a/pkg/controller/resourcegraphdefinition/controller_cleanup.go
+++ b/pkg/controller/resourcegraphdefinition/controller_cleanup.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/gobuffalo/flect"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kro-run/kro/api/v1alpha1"
 	"github.com/kro-run/kro/pkg/metadata"
@@ -31,8 +31,7 @@ import (
 // 1. Shuts down the microcontroller
 // 2. Deletes the associated CRD (if CRD deletion is enabled)
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinition(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
-	log, _ := logr.FromContext(ctx)
-	log.V(1).Info("cleaning up resource graph definition", "name", rgd.Name)
+	ctrl.LoggerFrom(ctx).V(1).Info("cleaning up resource graph definition", "name", rgd.Name)
 
 	// shutdown microcontroller
 	gvr := metadata.GetResourceGraphDefinitionInstanceGVR(rgd.Spec.Schema.Group, rgd.Spec.Schema.APIVersion, rgd.Spec.Schema.Kind)
@@ -66,8 +65,7 @@ func (r *ResourceGraphDefinitionReconciler) shutdownResourceGraphDefinitionMicro
 // If CRD deletion is disabled, it logs the skip and returns nil.
 func (r *ResourceGraphDefinitionReconciler) cleanupResourceGraphDefinitionCRD(ctx context.Context, crdName string) error {
 	if !r.allowCRDDeletion {
-		log, _ := logr.FromContext(ctx)
-		log.Info("skipping CRD deletion (disabled)", "crd", crdName)
+		ctrl.LoggerFrom(ctx).Info("skipping CRD deletion (disabled)", "crd", crdName)
 		return nil
 	}
 

--- a/pkg/controller/resourcegraphdefinition/controller_status.go
+++ b/pkg/controller/resourcegraphdefinition/controller_status.go
@@ -20,10 +20,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
-
 	"github.com/kro-run/kro/api/v1alpha1"
 	"github.com/kro-run/kro/pkg/metadata"
 )
@@ -143,8 +143,7 @@ func (r *ResourceGraphDefinitionReconciler) setResourceGraphDefinitionStatus(
 // setManaged sets the resourcegraphdefinition as managed, by adding the
 // default finalizer if it doesn't exist.
 func (r *ResourceGraphDefinitionReconciler) setManaged(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
-	log, _ := logr.FromContext(ctx)
-	log.V(1).Info("setting resourcegraphdefinition as managed")
+	ctrl.LoggerFrom(ctx).V(1).Info("setting resourcegraphdefinition as managed")
 
 	// Skip if finalizer already exists
 	if metadata.HasResourceGraphDefinitionFinalizer(rgd) {
@@ -159,8 +158,7 @@ func (r *ResourceGraphDefinitionReconciler) setManaged(ctx context.Context, rgd 
 // setUnmanaged sets the resourcegraphdefinition as unmanaged, by removing the
 // default finalizer if it exists.
 func (r *ResourceGraphDefinitionReconciler) setUnmanaged(ctx context.Context, rgd *v1alpha1.ResourceGraphDefinition) error {
-	log, _ := logr.FromContext(ctx)
-	log.V(1).Info("setting resourcegraphdefinition as unmanaged")
+	ctrl.LoggerFrom(ctx).V(1).Info("setting resourcegraphdefinition as unmanaged")
 
 	// Skip if finalizer already removed
 	if !metadata.HasResourceGraphDefinitionFinalizer(rgd) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2644,7 +2644,6 @@ func (m *mockResource) GetIncludeWhenExpressions() []string {
 	return m.conditions
 }
 
-
 func (m *mockResource) IsNamespaced() bool {
 	return m.namespaced
 }

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -149,7 +149,6 @@ func (e *Environment) setupController() error {
 	}()
 
 	rgReconciler := ctrlresourcegraphdefinition.NewResourceGraphDefinitionReconciler(
-		e.Client,
 		e.ClientSet,
 		e.ControllerConfig.AllowCRDDeletion,
 		dc,

--- a/test/integration/environment/setup.go
+++ b/test/integration/environment/setup.go
@@ -119,9 +119,7 @@ func (e *Environment) initializeClients() error {
 		return fmt.Errorf("creating client: %w", err)
 	}
 
-	e.CRDManager = e.ClientSet.CRD(kroclient.CRDWrapperConfig{
-		Log: noopLogger(),
-	})
+	e.CRDManager = e.ClientSet.CRD(kroclient.CRDWrapperConfig{})
 
 	restConfig := e.ClientSet.RESTConfig()
 	e.GraphBuilder, err = graph.NewBuilder(restConfig)
@@ -151,12 +149,12 @@ func (e *Environment) setupController() error {
 	}()
 
 	rgReconciler := ctrlresourcegraphdefinition.NewResourceGraphDefinitionReconciler(
-		noopLogger(),
 		e.Client,
 		e.ClientSet,
 		e.ControllerConfig.AllowCRDDeletion,
 		dc,
 		e.GraphBuilder,
+		1,
 	)
 
 	var err error


### PR DESCRIPTION
Leverages the context to grab the correct logger for each method that uses a logger in ResourceGraphDefinition controller.

Old log lines:
```
kro-86944cdcf6-l5td8 kro 2025-03-24T20:58:13.410Z	DEBUG	controller.resourceGraphDefinition	updating resource graph definition status	{"resourcegraphdefinition": {"name":"noop"}, "state": "Inactive", "conditions": 3}
kro-5d77854d9f-gtqmd kro 2025-03-24T21:31:02.982Z	LEVEL(-5)	Reconcile successful	{"controller": "resourcegraphdefinition", "controllerGroup": "kro.run", "controllerKind": "ResourceGraphDefinition", "ResourceGraphDefinition": {"name":"deploymentservice"}, "namespace": "", "name": "deploymentservice", "reconcileID": "579ac0e9-0902-4dcc-b220-8d104df1e911"}
```

New log lines:
```
kro-db65c46d7-q9r6g kro 2025-03-27T21:37:27.670Z	DEBUG	rgd-controller	updating resource graph definition status	{"controller": "ResourceGraphDefinition", "controllerGroup": "kro.run", "controllerKind": "ResourceGraphDefinition", "namespace": "", "name": "noop", "reconcileID": "28cd0c21-ac8b-4646-a1e4-d83b00d9b476", "state": "Active", "conditions": 3}
kro-db65c46d7-q9r6g kro 2025-03-27T21:37:27.681Z	LEVEL(-5)	rgd-controller	Reconcile successful	{"controller": "ResourceGraphDefinition", "controllerGroup": "kro.run", "controllerKind": "ResourceGraphDefinition", "namespace": "", "name": "noop", "reconcileID": "28cd0c21-ac8b-4646-a1e4-d83b00d9b476"}
```