### PR TITLE
update security contact information to Kro

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,5 @@
 # Security issue notifications
 
 If you discover a potential security issue in this project we ask that you
-notify AWS/Amazon Security via our
-[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+notify the kro authors via our email at security@kro.run.
 Please do **not** create a public github issue.


### PR DESCRIPTION
Replace AWS/Amazon security notification details with kro authors contact email.