### PR TITLE
Fix make build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"
 endif
 
-LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
+LDFLAGS="-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
         -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
         -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
-        -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
+        -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)"
 
 WITH_GOFLAGS = GOFLAGS="$(GOFLAGS)"
 

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -109,7 +109,6 @@ type ResourceDescriptor interface {
 	// be evaluated before deciding whether to create a resource
 	GetIncludeWhenExpressions() []string
 
-
 	// IsNamespaced returns true if the resource is namespaced, and false if it's
 	// cluster-scoped.
 	IsNamespaced() bool

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2644,7 +2644,6 @@ func (m *mockResource) GetIncludeWhenExpressions() []string {
 	return m.conditions
 }
 
-
 func (m *mockResource) IsNamespaced() bool {
 	return m.namespaced
 }


### PR DESCRIPTION
I did not quote the ld flags in the #452 which resulted in:

```
go build -ldflags=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v0.2.2-61-g35cb149-dirty -X sigs.k8s.io/release-utils/version.gitCommit=35cb149374379118d83c5ea619c6b93053577415 -X sigs.k8s.io/release-utils/version.gitTreeState="clean" -X sigs.k8s.io/release-utils/version.buildDate=none -o bin/controller ./cmd/controller/main.go
flag provided but not defined: -X
```

This quotes the `LDFLAGS` makefile var