### PR TITLE
Fix: Home page buttons spacing on mobile devices

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -53,6 +53,13 @@
   margin-left: 10px;
 }
 
+@media (max-width: 768px) {
+  .button {
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+}
+
 .button.button--primary {
   border: 2px solid var(--main-color);
 }


### PR DESCRIPTION
#### Before: 
![image](https://github.com/user-attachments/assets/09e06961-e0f1-440f-b6ba-4598569f2c76)

#### After the change: 
![image](https://github.com/user-attachments/assets/667b007c-7da7-4a57-9a9a-04fb46b1b61a)
