### PR TITLE
feat: enqueue instances on rgd update

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -110,13 +110,13 @@ const (
 	// InstanceUpdatePolicy is the annotation key for the instance update policy
 	InstanceUpdatePolicy = "kro.run/instance-update-policy"
 
-	// InstanceUpdatePolicyOnResourceGraphUpdate represents the update policy that leads to
+	// InstanceUpdatePolicyOnRGDUpdate represents the update policy that leads to
 	// a reconciliation of the instance after the corresponding resource graph is updated
-	InstanceUpdatePolicyOnResourceGraphUpdate = "on-resource-graph-update"
+	InstanceUpdatePolicyOnRGDUpdate = "on-rgd-update"
 
-	// InstanceUpdatePolicyIgnoreResourceGraphUpdate represents the update policy that explicitly
+	// InstanceUpdatePolicyIgnoreRGDUpdate represents the update policy that explicitly
 	// avoids reconciliation of the instance after the corresponding resource graph is updated
-	InstanceUpdatePolicyIgnoreResourceGraphUpdate = "ignore-resource-graph-update"
+	InstanceUpdatePolicyIgnoreRGDUpdate = "ignore-rgd-update"
 )
 
 // ResourceGraphDefinitionStatus defines the observed state of ResourceGraphDefinition

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -15,7 +15,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -106,6 +106,17 @@ const (
 	ResourceGraphDefinitionStateActive ResourceGraphDefinitionState = "Active"
 	// ResourceGraphDefinitionStateInactive represents the inactive state of the resource graph definition
 	ResourceGraphDefinitionStateInactive ResourceGraphDefinitionState = "Inactive"
+
+	// InstanceUpdatePolicy is the annotation key for the instance update policy
+	InstanceUpdatePolicy = "kro.run/instance-update-policy"
+
+	// InstanceUpdatePolicyOnResourceGraphUpdate represents the update policy that leads to
+	// a reconciliation of the instance after the corresponding resource graph is updated
+	InstanceUpdatePolicyOnResourceGraphUpdate = "on-resource-graph-update"
+
+	// InstanceUpdatePolicyIgnoreResourceGraphUpdate represents the update policy that explicitly
+	// avoids reconciliation of the instance after the corresponding resource graph is updated
+	InstanceUpdatePolicyIgnoreResourceGraphUpdate = "ignore-resource-graph-update"
 )
 
 // ResourceGraphDefinitionStatus defines the observed state of ResourceGraphDefinition
@@ -154,7 +165,7 @@ type ResourceGraphDefinition struct {
 	Status ResourceGraphDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // ResourceGraphDefinitionList contains a list of ResourceGraphDefinition
 type ResourceGraphDefinitionList struct {

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -431,14 +431,15 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 			return fmt.Errorf("failed to list objects for GVR %s: %w", gvr, err)
 		}
 		for _, obj := range objs.Items {
-			update, ok := obj.GetAnnotations()[v1alpha1.InstanceUpdatePolicy]
-			if !ok || update == "" {
-				update = v1alpha1.InstanceUpdatePolicyOnResourceGraphUpdate
+			updatePolicy, ok := obj.GetAnnotations()[v1alpha1.InstanceUpdatePolicy]
+			if !ok || updatePolicy == "" {
+				// default to reconcile on update of rgd
+				updatePolicy = v1alpha1.InstanceUpdatePolicyOnRGDUpdate
 			}
-			switch update {
-			case v1alpha1.InstanceUpdatePolicyOnResourceGraphUpdate:
+			switch updatePolicy {
+			case v1alpha1.InstanceUpdatePolicyOnRGDUpdate:
 				dc.enqueueObject(&obj, "update")
-			case v1alpha1.InstanceUpdatePolicyIgnoreResourceGraphUpdate:
+			case v1alpha1.InstanceUpdatePolicyIgnoreRGDUpdate:
 				dc.log.V(1).Info("Ignoring RGD update for object", "object", obj.GetName(), "gvr", gvr)
 			}
 		}

--- a/pkg/dynamiccontroller/dynamic_controller.go
+++ b/pkg/dynamiccontroller/dynamic_controller.go
@@ -64,6 +64,7 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/time/rate"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -423,6 +424,14 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 		// Even thought the informer is already registered, we should still
 		// still update the handler, as it might have changed.
 		dc.handlers.Store(gvr, handler)
+		// trigger reconciliation of the corresponding gvr's
+		objs, err := dc.kubeClient.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list objects for GVR %s: %w", gvr, err)
+		}
+		for _, obj := range objs.Items {
+			dc.enqueueObject(&obj, "update")
+		}
 		return nil
 	}
 
@@ -435,7 +444,6 @@ func (dc *DynamicController) StartServingGVK(ctx context.Context, gvr schema.Gro
 		"",
 		nil,
 	)
-
 	informer := gvkInformer.ForResource(gvr).Informer()
 
 	// Set up event handlers

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -150,8 +150,8 @@ func TestInstanceUpdatePolicy(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
 	gvk := schema.GroupVersionKind{Group: "test", Version: "v1", Kind: "Test"}
 	annotations := []map[string]string{
-		{v1alpha1.InstanceUpdatePolicy: v1alpha1.InstanceUpdatePolicyOnResourceGraphUpdate},
-		{v1alpha1.InstanceUpdatePolicy: v1alpha1.InstanceUpdatePolicyIgnoreResourceGraphUpdate},
+		{v1alpha1.InstanceUpdatePolicy: v1alpha1.InstanceUpdatePolicyOnRGDUpdate},
+		{v1alpha1.InstanceUpdatePolicy: v1alpha1.InstanceUpdatePolicyIgnoreRGDUpdate},
 		{v1alpha1.InstanceUpdatePolicy: ""},
 		{},
 	}
@@ -201,6 +201,6 @@ func TestInstanceUpdatePolicy(t *testing.T) {
 		name, _ := dc.queue.Get()
 		item := objs[name.NamespacedKey]
 		annotation, _ := item.(*unstructured.Unstructured).GetAnnotations()[v1alpha1.InstanceUpdatePolicy]
-		assert.NotEqual(t, annotation, v1alpha1.InstanceUpdatePolicyIgnoreResourceGraphUpdate)
+		assert.NotEqual(t, annotation, v1alpha1.InstanceUpdatePolicyIgnoreRGDUpdate)
 	}
 }

--- a/pkg/dynamiccontroller/dynamic_controller_test.go
+++ b/pkg/dynamiccontroller/dynamic_controller_test.go
@@ -196,6 +196,7 @@ func TestInstanceUpdatePolicy(t *testing.T) {
 	err = dc.StartServingGVK(context.Background(), gvr, handlerFunc)
 	assert.NoError(t, err)
 
+	// check if the expected objects are queued
 	assert.Equal(t, dc.queue.Len(), 3)
 	for dc.queue.Len() > 0 {
 		name, _ := dc.queue.Get()


### PR DESCRIPTION
**Enhancement**
Currently, when applying a modified `ResourceGraphDefinition`, the corresponding instance objects will not be enqueued for reconciliation. This means, the changes in the RGD do not take effect until the next reconciliation of the instance. If the instances are not modified, the next scheduled reconciliation occurs after the resync period of the dynamic controller.
This PR proposes a change to allow for a rather immediate reconciliation of corresponding instance objects.

This is also mentioned in this [issue](https://github.com/kro-run/kro/issues/188) and work on that has already been started in   [PR](https://github.com/kro-run/kro/pull/203).

TODO: @a-hilaly I'd like to revisit the idea of the update annotation. 



