### PR TITLE
fix:navbar buttons collision with searchbar in mobile screens

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -175,3 +175,68 @@ div[class^="announcementBar_"] {
   height: 100%;
   opacity: 1;
 }
+
+
+@media screen and (min-width: 997px) {
+  .navbar__items {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 996px) {
+  .navbar__items--right .navbar__item,
+  .header-github-link {
+    display: none !important;
+  }
+
+  .navbar__toggle,
+  .navbar__brand,
+  .navbar__search,
+  .navbar__items--left .navbar__item {
+    display: flex !important;
+  }
+
+  .navbar__search {
+    margin-right: 1rem;
+  }
+
+  .navbar__search-input {
+    width: 8rem !important;
+  }
+
+
+  .navbar__item {
+    padding: 0.5rem;
+  }
+}
+
+
+@media screen and (max-width: 488px) {
+  .navbar__items--left .navbar__item,
+  .navbar__items--right .navbar__item,
+  .header-github-link,
+  .navbar__link.navbar__item,
+  [class*="docSidebar"] {
+    display: none !important;
+  }
+
+  .navbar__toggle,
+  .navbar__brand,
+  .navbar__search {
+    display: flex !important;
+  }
+
+
+  .navbar__search {
+    margin-right: 1rem;
+  }
+
+  .navbar__search-input {
+    width: 10rem !important;
+  }
+}
+
+.navbar__search {
+  position: relative;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
Fixes #480 

Before :
Before they were getting collided with the search bar 

<img width="314" alt="Screenshot 2025-04-03 at 3 12 45 PM" src="https://github.com/user-attachments/assets/a0a962a9-0083-4cc8-a766-4bf3ea98189a" />


Now:
Currently I am hiding the buttons as they collide with the search button and user can access them via the menu button on mobile screens 


<img width="314" alt="Screenshot 2025-04-03 at 3 13 09 PM" src="https://github.com/user-attachments/assets/8be24144-952e-4640-aebe-a5261b5b2019" />

Other screen sizes

<img width="451" alt="Screenshot 2025-04-03 at 3 14 06 PM" src="https://github.com/user-attachments/assets/a5d8bc30-5da7-47c8-a952-f94db0058bb2" />
<img width="451" alt="Screenshot 2025-04-03 at 3 13 57 PM" src="https://github.com/user-attachments/assets/742c9f60-a322-4242-9a55-e12d05aeac05" />

cc: @a-hilaly 
