### PR TITLE
Implement tracking and garbage collection of orphaned resource

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -118,6 +118,8 @@ type ResourceGraphDefinitionStatus struct {
 	Conditions []Condition `json:"conditions,omitempty"`
 	// Resources represents the resources, and their information (dependencies for now)
 	Resources []ResourceInformation `json:"resources,omitempty"`
+	// ManagedResources tracks resources that are currently managed by this controller
+	ManagedResources []ManagedResource `json:"managedResources,omitempty"`
 }
 
 // ResourceInformation defines the information about a resource
@@ -134,6 +136,18 @@ type ResourceInformation struct {
 type Dependency struct {
 	// ID represents the id of the dependency resource
 	ID string `json:"id,omitempty"`
+}
+
+// ManagedResource represents a resource that is managed by the controller
+type ManagedResource struct {
+	// Kind represents the kind of the resource (e.g., Deployment, Service)
+	Kind string `json:"kind,omitempty"`
+	// Name represents the name of the resource
+	Name string `json:"name,omitempty"`
+	// Namespace represents the namespace of the resource
+	Namespace string `json:"namespace,omitempty"`
+	// ResourceID represents the ID of the resource in the ResourceGraphDefinition
+	ResourceID string `json:"resourceID,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
 What does this PR do?
This pull request addresses issue #187 by introducing a robust mechanism for tracking and garbage collecting orphaned resources. These resources may become orphaned when users modify ResourceGroup templates or change `includeWhen` conditions.

Key Changes:
- Introduced a `managedResources` field in the `ResourceGraphDefinitionStatus` struct to maintain a list of actively managed resources.
- Implemented `findOrphanedResources` to detect resources no longer referenced in the desired state.
- Added a `deleteResource` helper function for safe and structured deletion of orphaned resources.
- Enhanced the `Reconcile` method to integrate tracking and automatic cleanup logic during reconciliation.

Additional Notes:
- No new dependencies were added.
- Testing should focus on verifying the deletion of obsolete resources post-template modification or condition changes.

 Demo / Screenshots:
- N/A
