### PR TITLE
Fix infinite loop in fieldPath parser for single-letter field names

### DIFF
--- a/pkg/graph/fieldpath/parser.go
+++ b/pkg/graph/fieldpath/parser.go
@@ -73,8 +73,7 @@ func (p *parser) parse() ([]Segment, error) {
 				return nil, err
 			}
 			segments = append(segments, Segment{Name: field, Index: -1})
-
-		} else if p.pos+1 < p.len && p.input[p.pos] != '[' {
+		} else if p.pos < p.len && p.input[p.pos] != '[' {
 			// Parse unquoted field until we hit a [ or .
 			field, err := p.parseUnquotedField()
 			if err != nil {

--- a/pkg/graph/fieldpath/parser_test.go
+++ b/pkg/graph/fieldpath/parser_test.go
@@ -26,6 +26,14 @@ func TestParse(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "simple single letter path",
+			path: "data.A",
+			want: []Segment{
+				{Name: "data", Index: -1},
+				{Name: "A", Index: -1},
+			},
+		},
+		{
 			name: "simple path",
 			path: "spec.containers",
 			want: []Segment{


### PR DESCRIPTION
Field names with just a single letter, say 'data.A' for a data field in a configmap would result in an infinite loop.