### PR TITLE
feat: Add support for (custom) types

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -72,6 +72,12 @@ type Schema struct {
 	// the CRD that the resourcegraphdefinition is managing. This is adhering
 	// to the SimpleSchema spec
 	Spec runtime.RawExtension `json:"spec,omitempty"`
+
+	// Types is a map of custom type definitions. These can be used in the spec
+	// of the resourcegraphdefinition. Each type definition is also adhering to
+	// the SimpleSchema spec.
+	Types runtime.RawExtension `json:"types,omitempty"`
+
 	// The status of the resourcegraphdefinition. This is the status of the CRD
 	// that the resourcegraphdefinition is managing. This is adhering to the
 	// SimpleSchema spec.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -246,6 +246,7 @@ func (in *ResourceInformation) DeepCopy() *ResourceInformation {
 func (in *Schema) DeepCopyInto(out *Schema) {
 	*out = *in
 	in.Spec.DeepCopyInto(&out.Spec)
+	in.Types.DeepCopyInto(&out.Types)
 	in.Status.DeepCopyInto(&out.Status)
 	if in.Validation != nil {
 		in, out := &in.Validation, &out.Validation

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -135,6 +135,13 @@ spec:
                       SimpleSchema spec.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  types:
+                    description: |-
+                      Types is a map of custom type definitions. These can be used in the spec
+                      of the resourcegraphdefinition. Each type definition is also adhering to
+                      the SimpleSchema spec.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   validation:
                     description: |-
                       Validation is a list of validation rules that are applied to the

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -135,6 +135,13 @@ spec:
                       SimpleSchema spec.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  types:
+                    description: |-
+                      Types is a map of custom type definitions. These can be used in the spec
+                      of the resourcegraphdefinition. Each type definition is also adhering to
+                      the SimpleSchema spec.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   validation:
                     description: |-
                       Validation is a list of validation rules that are applied to the

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -514,8 +514,16 @@ func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps,
 		return nil, fmt.Errorf("failed to unmarshal spec schema: %w", err)
 	}
 
+	// Also the custom types must be unmarshalled to a map[string]interface{} to
+	// make handling easier.
+	customTypes := map[string]interface{}{}
+	err = yaml.UnmarshalStrict(rgSchema.Types.Raw, &customTypes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal predefined types: %w", err)
+	}
+
 	// The instance resource has a schema defined using the "SimpleSchema" format.
-	instanceSchema, err := simpleschema.ToOpenAPISpec(instanceSpec)
+	instanceSchema, err := simpleschema.ToOpenAPISpec(instanceSpec, customTypes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build OpenAPI schema for instance: %v", err)
 	}

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -435,14 +435,6 @@ func (b *Builder) buildInstanceResource(
 	// The instance resource is a Kubernetes resource, so it has a GroupVersionKind.
 	gvk := metadata.GetResourceGraphDefinitionInstanceGVK(group, apiVersion, kind)
 
-	// We need to unmarshal the instance schema to a map[string]interface{} to
-	// make it easier to work with.
-	unstructuredInstance := map[string]interface{}{}
-	err := yaml.UnmarshalStrict(rgDefinition.Spec.Raw, &unstructuredInstance)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal instance schema: %w", err)
-	}
-
 	// The instance resource has a schema defined using the "SimpleSchema" format.
 	instanceSpecSchema, err := buildInstanceSpecSchema(rgDefinition)
 	if err != nil {

--- a/pkg/simpleschema/simplerschema.go
+++ b/pkg/simpleschema/simplerschema.go
@@ -21,10 +21,17 @@ import (
 
 // ToOpenAPISpec converts a SimpleSchema object to an OpenAPI schema.
 //
-// The input object is a map[string]interface{} where the key is the field name
-// and the value is the field type.
-func ToOpenAPISpec(obj map[string]interface{}) (*extv1.JSONSchemaProps, error) {
+// The first input obj is a map[string]interface{} where the key is the field
+// name and the value is the field type.
+//
+// The second input customTypes is a map[string]interface{} where the key is
+// the type name and the value its specification. These custom types will be
+// available as predefined types in the transformer.
+func ToOpenAPISpec(obj map[string]interface{}, customTypes map[string]interface{}) (*extv1.JSONSchemaProps, error) {
 	tf := newTransformer()
+	if err := tf.loadPreDefinedTypes(customTypes); err != nil {
+		return nil, err
+	}
 	return tf.buildOpenAPISchema(obj)
 }
 

--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -15,21 +15,31 @@ package simpleschema
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+// A predefined type is a type that is predefined in the schema.
+// It is used to resolve references in the schema, while capturing the fact
+// whether the type has the required marker set (this information would
+// otherwise be lost in the parsing process).
+type predefinedType struct {
+	Schema   extv1.JSONSchemaProps
+	Required bool
+}
+
 // transformer is a transformer for OpenAPI schemas
 type transformer struct {
-	preDefinedTypes map[string]extv1.JSONSchemaProps
+	preDefinedTypes map[string]predefinedType
 }
 
 // newTransformer creates a new transformer
 func newTransformer() *transformer {
 	return &transformer{
-		preDefinedTypes: make(map[string]extv1.JSONSchemaProps),
+		preDefinedTypes: make(map[string]predefinedType),
 	}
 }
 
@@ -39,7 +49,7 @@ func newTransformer() *transformer {
 // As of today, kro doesn't support custom types in the schema - do
 // not use this function.
 func (t *transformer) loadPreDefinedTypes(obj map[string]interface{}) error {
-	t.preDefinedTypes = make(map[string]extv1.JSONSchemaProps)
+	t.preDefinedTypes = make(map[string]predefinedType)
 
 	jsonSchemaProps, err := t.buildOpenAPISchema(obj)
 	if err != nil {
@@ -47,7 +57,11 @@ func (t *transformer) loadPreDefinedTypes(obj map[string]interface{}) error {
 	}
 
 	for k, properties := range jsonSchemaProps.Properties {
-		t.preDefinedTypes[k] = properties
+		required := false
+		if slices.Contains(jsonSchemaProps.Required, k) {
+			required = true
+		}
+		t.preDefinedTypes[k] = predefinedType{Schema: properties, Required: required}
 	}
 	return nil
 }
@@ -114,7 +128,10 @@ func (tf *transformer) parseFieldSchema(key, fieldValue string, parentSchema *ex
 		if !ok {
 			return nil, fmt.Errorf("unknown type: %s", fieldType)
 		}
-		fieldJSONSchemaProps = &preDefinedType
+		fieldJSONSchemaProps = &preDefinedType.Schema
+		if preDefinedType.Required {
+			parentSchema.Required = append(parentSchema.Required, key)
+		}
 	}
 
 	if err := tf.applyMarkers(fieldJSONSchemaProps, markers, key, parentSchema); err != nil {
@@ -147,7 +164,7 @@ func (tf *transformer) handleMapType(key, fieldType string) (*extv1.JSONSchemaPr
 		}
 		fieldJSONSchemaProps.AdditionalProperties.Schema = valueSchema
 	} else if preDefinedType, ok := tf.preDefinedTypes[valueType]; ok {
-		fieldJSONSchemaProps.AdditionalProperties.Schema = &preDefinedType
+		fieldJSONSchemaProps.AdditionalProperties.Schema = &preDefinedType.Schema
 	} else if isAtomicType(valueType) {
 		fieldJSONSchemaProps.AdditionalProperties.Schema.Type = valueType
 	} else {
@@ -179,7 +196,7 @@ func (tf *transformer) handleSliceType(key, fieldType string) (*extv1.JSONSchema
 	} else if isAtomicType(elementType) {
 		fieldJSONSchemaProps.Items.Schema.Type = elementType
 	} else if preDefinedType, ok := tf.preDefinedTypes[elementType]; ok {
-		fieldJSONSchemaProps.Items.Schema = &preDefinedType
+		fieldJSONSchemaProps.Items.Schema = &preDefinedType.Schema
 	} else {
 		return nil, fmt.Errorf("unknown type: %s", elementType)
 	}

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -531,7 +531,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 				"alias": "string",
 			},
 			want: map[string]predefinedType{
-				"alias": predefinedType{
+				"alias": {
 					Schema: extv1.JSONSchemaProps{
 						Type: "string",
 					},
@@ -546,7 +546,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 				"alias": "string | required=true default=\"test\"",
 			},
 			want: map[string]predefinedType{
-				"alias": predefinedType{
+				"alias": {
 					Schema: extv1.JSONSchemaProps{
 						Type:    "string",
 						Default: &extv1.JSON{Raw: []byte("\"test\"")},

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -20,6 +20,10 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
 func TestBuildOpenAPISchema(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -425,6 +429,26 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "Custom simple type (required)",
+			obj: map[string]interface{}{
+				"myValue": "myType",
+			},
+			types: map[string]interface{}{
+				"myType": "string | required=true description=\"my description\"",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"myValue": {
+						Type:        "string",
+						Description: "my description",
+					},
+				},
+				Required: []string{"myValue"},
+			},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -21,27 +21,10 @@ import (
 )
 
 func TestBuildOpenAPISchema(t *testing.T) {
-	transformer := newTransformer()
-
-	// Load pre-defined types
-	err := transformer.loadPreDefinedTypes(map[string]interface{}{
-		"Address": map[string]interface{}{
-			"street":  "string",
-			"city":    "string",
-			"country": "string",
-		},
-		"Person": map[string]interface{}{
-			"name": "string",
-			"age":  "integer",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Failed to load pre-defined types: %v", err)
-	}
-
 	tests := []struct {
 		name    string
 		obj     map[string]interface{}
+		types   map[string]interface{}
 		want    *extv1.JSONSchemaProps
 		wantErr bool
 	}{
@@ -60,6 +43,17 @@ func TestBuildOpenAPISchema(t *testing.T) {
 				"scores":     "[]integer",
 				"attributes": "map[string]boolean",
 				"friends":    "[]Person",
+			},
+			types: map[string]interface{}{
+				"Address": map[string]interface{}{
+					"street":  "string",
+					"city":    "string",
+					"country": "string",
+				},
+				"Person": map[string]interface{}{
+					"name": "string",
+					"age":  "integer",
+				},
 			},
 			want: &extv1.JSONSchemaProps{
 				Type:     "object",
@@ -215,6 +209,12 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			obj: map[string]interface{}{
 				"matrix": "[][][]Person",
 			},
+			types: map[string]interface{}{
+				"Person": map[string]interface{}{
+					"name": "string",
+					"age":  "integer",
+				},
+			},
 			want: &extv1.JSONSchemaProps{
 				Type: "object",
 				Properties: map[string]extv1.JSONSchemaProps{
@@ -249,6 +249,12 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			name: "Nested maps",
 			obj: map[string]interface{}{
 				"matrix": "map[string]map[string]map[string]Person",
+			},
+			types: map[string]interface{}{
+				"Person": map[string]interface{}{
+					"name": "string",
+					"age":  "integer",
+				},
 			},
 			want: &extv1.JSONSchemaProps{
 				Type: "object",
@@ -424,7 +430,7 @@ func TestBuildOpenAPISchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := transformer.buildOpenAPISchema(tt.obj)
+			got, err := ToOpenAPISpec(tt.obj, tt.types)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildOpenAPISchema() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -20,10 +20,6 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-func floatPtr(f float64) *float64 {
-	return &f
-}
-
 func TestBuildOpenAPISchema(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -468,7 +468,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 	tests := []struct {
 		name    string
 		obj     map[string]interface{}
-		want    map[string]extv1.JSONSchemaProps
+		want    map[string]predefinedType
 		wantErr bool
 	}{
 		{
@@ -487,34 +487,71 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 					"employees": "[]string",
 				},
 			},
-			want: map[string]extv1.JSONSchemaProps{
+			want: map[string]predefinedType{
 				"Person": {
-					Type: "object",
-					Properties: map[string]extv1.JSONSchemaProps{
-						"name": {Type: "string"},
-						"age":  {Type: "integer"},
-						"address": {
-							Type: "object",
-							Properties: map[string]extv1.JSONSchemaProps{
-								"street": {Type: "string"},
-								"city":   {Type: "string"},
-							},
-						},
-					},
-				},
-				"Company": {
-					Type: "object",
-					Properties: map[string]extv1.JSONSchemaProps{
-						"name": {Type: "string"},
-						"employees": {
-							Type: "array",
-							Items: &extv1.JSONSchemaPropsOrArray{
-								Schema: &extv1.JSONSchemaProps{
-									Type: "string",
+					Schema: extv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: "string"},
+							"age":  {Type: "integer"},
+							"address": {
+								Type: "object",
+								Properties: map[string]extv1.JSONSchemaProps{
+									"street": {Type: "string"},
+									"city":   {Type: "string"},
 								},
 							},
 						},
 					},
+					Required: false,
+				},
+				"Company": {
+					Schema: extv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]extv1.JSONSchemaProps{
+							"name": {Type: "string"},
+							"employees": {
+								Type: "array",
+								Items: &extv1.JSONSchemaPropsOrArray{
+									Schema: &extv1.JSONSchemaProps{
+										Type: "string",
+									},
+								},
+							},
+						},
+					},
+					Required: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Simple type alias",
+			obj: map[string]interface{}{
+				"alias": "string",
+			},
+			want: map[string]predefinedType{
+				"alias": predefinedType{
+					Schema: extv1.JSONSchemaProps{
+						Type: "string",
+					},
+					Required: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Simple type alias with markers",
+			obj: map[string]interface{}{
+				"alias": "string | required=true default=\"test\"",
+			},
+			want: map[string]predefinedType{
+				"alias": predefinedType{
+					Schema: extv1.JSONSchemaProps{
+						Type:    "string",
+						Default: &extv1.JSON{Raw: []byte("\"test\"")},
+					},
+					Required: true,
 				},
 			},
 			wantErr: false,
@@ -524,7 +561,7 @@ func TestLoadPreDefinedTypes(t *testing.T) {
 			obj: map[string]interface{}{
 				"invalid": 123,
 			},
-			want:    map[string]extv1.JSONSchemaProps{},
+			want:    map[string]predefinedType{},
 			wantErr: true,
 		},
 	}

--- a/website/docs/docs/concepts/10-simple-schema.md
+++ b/website/docs/docs/concepts/10-simple-schema.md
@@ -129,7 +129,7 @@ schema:
       name: string
       age: integer
   spec:
-    people: '[]person | required=true`
+    people: '[]Person | required=true`
 ```
 
 ## Validation and Documentation

--- a/website/docs/docs/concepts/10-simple-schema.md
+++ b/website/docs/docs/concepts/10-simple-schema.md
@@ -33,7 +33,13 @@ spec:
       ports: "[]integer"
 
       # Map type
-      env: "map[string]string"
+      env: "map[string]mytype"
+
+    # Custom Types
+    types:
+      myType:
+        value1: string | required=true
+        value2: integer | default=42
 
     status:
       # Status fields with auto-inferred types
@@ -107,6 +113,23 @@ Examples:
 ```yaml
 labels: "map[string]string"
 metrics: "map[string]float"
+```
+
+### Custom Types
+
+Custom types are specified in the separate `types` section.
+They provide a map of names to type specifications, that follow the simple schema.
+
+Example:
+
+```yaml
+schema:
+  types:
+    Person:
+      name: string
+      age: integer
+  spec:
+    people: '[]person | required=true`
 ```
 
 ## Validation and Documentation


### PR DESCRIPTION
This is the first implementation that was discussed in the slack channel. The other idea of having the `types` field in the `spec` part of the schema, seems to be more complicated to implement.

Fixes #144.
