### PR TITLE
Fix field schema parsing

### DIFF
--- a/pkg/simpleschema/field.go
+++ b/pkg/simpleschema/field.go
@@ -35,10 +35,7 @@ func parseFieldSchema(fieldSchema string) (string, []*Marker, error) {
 	}
 
 	// split the type and markers if possible
-	parts := strings.Split(fieldSchema, "|")
-	if len(parts) > 2 {
-		return "", nil, fmt.Errorf("invalid type: %s", fieldSchema)
-	}
+	parts := strings.SplitN(fieldSchema, "|", 2)
 
 	// trim spaces from the type
 	typ := strings.TrimSpace(parts[0])

--- a/pkg/simpleschema/field_test.go
+++ b/pkg/simpleschema/field_test.go
@@ -71,6 +71,15 @@ func TestParseFieldSchema(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:        "array field with complex validation",
+			fieldSchema: "[]string | validation=\"self.all(x, startsWith(x, 'foo') || startsWith(x, 'bar'))\"",
+			wantType:    "[]string",
+			wantMarkers: []*Marker{
+				{MarkerType: MarkerTypeValidation, Key: "validation", Value: "self.all(x, startsWith(x, 'foo') || startsWith(x, 'bar'))"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The CEL expressions in a validation marker can use `||` for 'or' expressions. Therefore, the test for at most two elements would fail in these cases. Fix is to just split once.

Related to #347.