### PR TITLE
Implement validating admission policies

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -78,8 +78,7 @@ type Schema struct {
 	Status runtime.RawExtension `json:"status,omitempty"`
 	// Validation is a list of validation rules that are applied to the
 	// resourcegraphdefinition.
-	// Not implemented yet.
-	Validation []string `json:"validation,omitempty"`
+	Validation []Validation `json:"validation,omitempty"`
 }
 
 type Validation struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -236,7 +236,7 @@ func (in *Schema) DeepCopyInto(out *Schema) {
 	in.Status.DeepCopyInto(&out.Status)
 	if in.Validation != nil {
 		in, out := &in.Validation, &out.Validation
-		*out = make([]string, len(*in))
+		*out = make([]Validation, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -139,9 +139,13 @@ spec:
                     description: |-
                       Validation is a list of validation rules that are applied to the
                       resourcegraphdefinition.
-                      Not implemented yet.
                     items:
-                      type: string
+                      properties:
+                        expression:
+                          type: string
+                        message:
+                          type: string
+                      type: object
                     type: array
                 required:
                 - apiVersion

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -139,9 +139,13 @@ spec:
                     description: |-
                       Validation is a list of validation rules that are applied to the
                       resourcegraphdefinition.
-                      Not implemented yet.
                     items:
-                      type: string
+                      properties:
+                        expression:
+                          type: string
+                        message:
+                          type: string
+                      type: object
                     type: array
                 required:
                 - apiVersion

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -534,6 +534,16 @@ func buildInstanceSpecSchema(rgSchema *v1alpha1.Schema) (*extv1.JSONSchemaProps,
 	if err != nil {
 		return nil, fmt.Errorf("failed to build OpenAPI schema for instance: %v", err)
 	}
+
+	// Add the validating admission policies defined in the instance spec.
+	instanceSchema.XValidations = make(extv1.ValidationRules, len(rgSchema.Validation))
+	for idx, validation := range rgSchema.Validation {
+		instanceSchema.XValidations[idx] = extv1.ValidationRule{
+			Message: validation.Message,
+			Rule:    validation.Expression,
+		}
+	}
+
 	return instanceSchema, nil
 }
 

--- a/pkg/graph/builder_test.go
+++ b/pkg/graph/builder_test.go
@@ -976,6 +976,29 @@ func TestGraphBuilder_DependencyValidation(t *testing.T) {
 				}, g.TopologicalOrder)
 			},
 		},
+		{
+			name: "check validation expression",
+			resourceGraphDefinitionOpts: []generator.ResourceGraphDefinitionOption{
+				generator.WithSchema(
+					"Test", "v1alpha1",
+					map[string]interface{}{
+						"name": "string",
+					},
+					nil,
+				),
+				generator.WithValidation("rule", "message"),
+			},
+			validateDeps: func(t *testing.T, g *Graph) {
+				require.Len(t, g.Instance.crd.Spec.Versions, 1)
+				schema := g.Instance.crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+				require.Contains(t, schema.Properties, "spec")
+				spec := schema.Properties["spec"]
+
+				require.Len(t, spec.XValidations, 1)
+				assert.Equal(t, "rule", spec.XValidations[0].Rule)
+				assert.Equal(t, "message", spec.XValidations[0].Message)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/testutil/generator/resourcegraphdefinition.go
+++ b/pkg/testutil/generator/resourcegraphdefinition.go
@@ -92,3 +92,12 @@ func WithResource(
 		})
 	}
 }
+
+func WithValidation(expression, message string) ResourceGraphDefinitionOption {
+	return func(rgd *krov1alpha1.ResourceGraphDefinition) {
+		rgd.Spec.Schema.Validation = append(rgd.Spec.Schema.Validation, krov1alpha1.Validation{
+			Expression: expression,
+			Message:    message,
+		})
+	}
+}

--- a/website/docs/docs/concepts/00-resource-group-definitions.md
+++ b/website/docs/docs/concepts/00-resource-group-definitions.md
@@ -94,6 +94,11 @@ schema:
     # Types are inferred from these CEL expressions
     availableReplicas: ${deployment.status.availableReplicas}
     conditions: ${deployment.status.conditions}
+
+  validation:
+    # Validating admission policies added to the new API type's CRD
+    - expression: "${ self.image == 'nginx' || !self.ingress.enabled }"
+      message: "Only nginx based applications can have ingress enabled"
 ```
 
 **kro** follows a different approach for defining your API schema and shapes. It


### PR DESCRIPTION
This uses the prepared `Validation` field of the RGD to enable validating admission policies. Changed the type from `[]string` to `[]Validation` to support custom messages.

NOTE: Documentation is missing, but I'm unsure where to put it.