### PR TITLE
Fix required marker value handling

### DIFF
--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -16,6 +16,7 @@ package simpleschema
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -459,10 +459,10 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			name: "Required Marker handling",
 			obj: map[string]interface{}{
 				"req_1":     "string | required=true",
-				"req_2":     "string | required=yes",
+				"req_2":     "string | required=True",
 				"req_3":     "string | required=1",
 				"not_req_1": "string | required=false",
-				"not_req_2": "string | required=no",
+				"not_req_2": "string | required=False",
 			},
 			want: &extv1.JSONSchemaProps{
 				Type: "object",

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -447,6 +447,36 @@ func TestBuildOpenAPISchema(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Invalid Required Marker value",
+			obj: map[string]interface{}{
+				"data": "string | required=invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Required Marker handling",
+			obj: map[string]interface{}{
+				"req_1":     "string | required=true",
+				"req_2":     "string | required=yes",
+				"req_3":     "string | required=1",
+				"not_req_1": "string | required=false",
+				"not_req_2": "string | required=no",
+			},
+			want: &extv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]extv1.JSONSchemaProps{
+					"req_1":     {Type: "string"},
+					"req_2":     {Type: "string"},
+					"req_3":     {Type: "string"},
+					"not_req_1": {Type: "string"},
+					"not_req_2": {Type: "string"},
+				},
+				Required: []string{"req_1", "req_2", "req_3"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It will now check the values and handle them accordingly. The truthy values are "true", "yes", and "1". The supported falsey values are "false" and "no".

Any other value will return an error.