### PR TITLE
docs: add governance page to website

### DIFF
--- a/website/docs/docs/governance.md
+++ b/website/docs/docs/governance.md
@@ -1,0 +1,26 @@
+---
+sidebar_label: "Governance"
+sidebar_position: 150
+---
+
+# Governance
+
+**kro** is not a CNCF project, but follows the CNCF governance model,
+which is designed to ensure that the project is run in a transparent
+and inclusive manner. kro is currently governed by a small group of
+maintainers - from Google, Amazon, and Microsoft - who are responsible
+for the overall direction and management of the project, as well as
+for the technical decisions that affect the project.
+
+## Quick links:
+- [Governance model][Governance model]
+- [Maintainers list][Maintainers list]
+- [Code of conduct][Code of conduct]
+- [Contributing guidelines][Contributing guidelines]
+- [License][License] (Apache 2.0)
+
+[Governance model]:https://github.com/kro-run/kro/blob/main/GOVERNANCE.md
+[Maintainers list]:https://github.com/kro-run/kro/blob/main/MAINTAINERS.md
+[Code of conduct]:https://github.com/kro-run/kro/blob/main/CODE_OF_CONDUCT.md
+[License]:https://github.com/kro-run/kro/blob/main/LICENSE
+[Contributing guidelines]:https://github.com/kro-run/kro/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
Add a new governance.md file that documents the CNCF governance model for kro,
including links to governance model, maintainers list, code of conduct,
contributing guidelines, and license.

Co-authored-by: Micah Hausler <mhausler@amazon.com>