### PR TITLE
feat: Add CRD watch to trigger `ResourceGraphDefinition` reconciliation

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/zapcore"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(xv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(extv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Add a watch for `v1.CustomResourceDefinition` updates to immediately reconcile
the owning `ResourceGraphDefinition` when a CRD is manually modified.

This ensures that any external modifications to CRDs are detected and automatically
reverted to maintain consistency with their ResourceGraphDefinition specifications.

Many thanks to Roi Nisimi <roi.nisimi@orca.security> for catching and reporting this one!

Co-authored-by: Roi Nisimi <roi.nisimi@orca.security>