### PR TITLE
Fix `TestInstanceUpdate` kind name conflicts in integration tests

### DIFF
--- a/test/integration/suites/core/lifecycle_test.go
+++ b/test/integration/suites/core/lifecycle_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Update", func() {
 		// Create ResourceGraphDefinition for a simple deployment service
 		rgd := generator.NewResourceGraphDefinition("test-update",
 			generator.WithSchema(
-				"TestUpdate", "v1alpha1",
+				"TestInstanceUpdate", "v1alpha1",
 				map[string]interface{}{
 					"replicas": "integer | default=1",
 					"image":    "string | default=nginx:latest",
@@ -110,7 +110,7 @@ var _ = Describe("Update", func() {
 		instance := &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": fmt.Sprintf("%s/%s", krov1alpha1.KRODomainName, "v1alpha1"),
-				"kind":       "TestUpdate",
+				"kind":       "TestInstanceUpdate",
 				"metadata": map[string]interface{}{
 					"name":      "test-instance-for-updates",
 					"namespace": namespace,


### PR DESCRIPTION
This commit resolves a naming conflict in integration tests where the "TestUpdate" kind
was being used in both the Update and CRD test suites, causing test failures due to
conflicting CRD definitions.

While fixing this, I noticed we should be more careful about resource ownership in general.
kro should respect ownership labels not just for CRDs but for all managed resources.
Before modifying any resource (CRD or managed resources), we should verify its actually
"ours" by checking the ownership labels. This would prevent the exact type of conflict we
saw here, where one RGD might accidentally modify resources that belong to other RGDs.