### PR TITLE
Docs: Fix the instance status in docs to reflect actual values

### DIFF
--- a/website/docs/docs/concepts/15-instances.md
+++ b/website/docs/docs/concepts/15-instances.md
@@ -63,7 +63,9 @@ my-app   ACTIVE    true     30s
 ```
 
 For detailed status, check the instance's YAML:
-
+```bash
+kubectl edit webapplication my-app
+```
 ```yaml
 status:
   state: ACTIVE # High-level instance state
@@ -82,10 +84,11 @@ Every instance includes:
 
 1. **State**: High-level status
 
-   - `Running`: All resources are ready
-   - `Progressing`: Working towards desired state
-   - `Failed`: Error occurred
-   - `Terminating`: Being deleted
+   - `ACTIVE`: All resources are ready
+   - `IN_PROGRESS`: Instance Progressing towards desired state
+   - `FAILED`: Instance failed during creation
+   - `DELETING`: Being deleted
+   - `ERROR`: Error occurred
 
 2. **Conditions**: Detailed status information
 
@@ -94,7 +97,7 @@ Every instance includes:
    - `Degraded`: Operating but not optimal
    - `Error`: Problems detected
 
-3. **Resource Status**: Status from your resources
+3. **Resource Status**: Status from your RGD's spec/schema subresource
    - Values you defined in your ResourceGraphDefinition's status section
    - Automatically updated as resources change
 


### PR DESCRIPTION
In this section of the docs:
https://kro.run/docs/concepts/instances#understanding-status

the possible state values for the instance `status.state` were misleading, which might create confusion for new users reading the docs. I have verified this by observing the actual `status.state` field in instance objects, as well as checking the code here:
https://github.com/kro-run/kro/blob/5e886e5e4d14bd1b5e9d3a2ac91d38ddac05a7e4/pkg/controller/instance/instance_state.go

This change updates the documentation to reflect the accurate state values, making it more developer-friendly and clearer.

Thanks! Looking forward to contributing more to kro.