### PR TITLE
Allow ResourceGraphDefinition authors to maintain serveral versions

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -61,7 +61,6 @@ type Schema struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="apiVersion is immutable"
 	APIVersion string `json:"apiVersion,omitempty"`
 	// The group of the resourcegraphdefinition. This is used to set the API group
 	// of the generated CRD. If omitted, it defaults to "kro.run".

--- a/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
+++ b/config/crd/bases/kro.run_resourcegraphdefinitions.yaml
@@ -178,9 +178,6 @@ spec:
                       and create the CRD for the resourcegraphdefinition.
                     pattern: ^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$
                     type: string
-                    x-kubernetes-validations:
-                    - message: apiVersion is immutable
-                      rule: self == oldSelf
                   group:
                     default: kro.run
                     description: |-

--- a/helm/crds/kro.run_resourcegraphdefinitions.yaml
+++ b/helm/crds/kro.run_resourcegraphdefinitions.yaml
@@ -178,9 +178,6 @@ spec:
                       and create the CRD for the resourcegraphdefinition.
                     pattern: ^v[0-9]+(alpha[0-9]+|beta[0-9]+)?$
                     type: string
-                    x-kubernetes-validations:
-                    - message: apiVersion is immutable
-                      rule: self == oldSelf
                   group:
                     default: kro.run
                     description: |-


### PR DESCRIPTION
In the issue https://github.com/kro-run/kro/issues/482 I initially proposed a way that would allow RGD authors to declare multiple versions in their RGD. However, after trying to implement a POC I realized that providing this kind of support would make the implementation too complex, specially when handling changes in the resource graph. Besides, from a UX standpoint it would not be too pleasant either as users would need to move what has changed from `schema` to `previousSchema` which could introduce unwanted errors.

This PR proposes a different approach, still based on some of the conventions mentioned in the issue, namely...

- `spec.schema.apiVersion` will always be the latest version of the underlying CRD
- `spec.schema.apiVersion` will always be both the served and storage version.

And defining the latest version in the underlying CRD as the one where both served and storage are true.

Kro will detect when the schema's apiVersion has changed and add it to the underlying CRD. As described here https://github.com/kro-run/kro/issues/482#issuecomment-2918999073 the limitation is that RGD authors will only see all the available versions if they inspect the underlying CRD. If we follow through with this approach maybe the Kro CLI can help mitigate that limitation somehow?

This PR is missing validation:
- is it a version older than the current latest version
- is it not one of the existing previous versions?

If you find this approach valid, I am happy to continue with the implementation.

#### How to test

Create a RGD

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: my-application
spec:
  schema:
    apiVersion: v1alpha1
    kind: Application
    spec:
      # Spec fields that users can provide.
      name: string
      image: string | default="nginx"
    status:
      deploymentConditions: ${deployment.status.conditions}
      availableReplicas: ${deployment.status.availableReplicas}
  resources:
    - id: deployment
      template:
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: ${schema.spec.name} 
        spec:
          replicas: 3
          selector:
            matchLabels:
              app: ${schema.spec.name}
          template:
            metadata:
              labels:
                app: ${schema.spec.name}
            spec:
              containers:
                - name: ${schema.spec.name}
                  image: ${schema.spec.image} # Use the image provided by user
                  ports:
                    - containerPort: 80
```

Then create a new version

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: my-application
spec:
  schema:
    apiVersion: v1alpha2
    kind: Application
    spec:
      # Spec fields that users can provide.
      name: string
      image:
        repository: string | default="nginx"
        tag: string | default="latest"
    status:
      deploymentConditions: ${deployment.status.conditions}
      availableReplicas: ${deployment.status.availableReplicas}
  resources:
    - id: deployment
      template:
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: ${schema.spec.name} # Use the name provided by user
        spec:
          replicas: 3
          selector:
            matchLabels:
              app: ${schema.spec.name}
          template:
            metadata:
              labels:
                app: ${schema.spec.name}
            spec:
              containers:
                - name: ${schema.spec.name}
                  image: ${schema.spec.image.repository}:${schema.spec.image.tag} # Use the image provided by user
                  ports:
                    - containerPort: 80
```
