### PR TITLE
docs: Fix typos in Markdown documentation files

### DIFF
--- a/examples/aws/ack-controller/README.md
+++ b/examples/aws/ack-controller/README.md
@@ -68,7 +68,7 @@ The controllers are using the IAM controller to create the necessary roles for t
    ```
 6. Install the combined instance:
 
-   All contollers are enable by default. 
+   All controllers are enable by default. 
    
    ```
    kubectl apply -f instance.yaml

--- a/examples/aws/webstack/Readme.md
+++ b/examples/aws/webstack/Readme.md
@@ -78,7 +78,7 @@ spec:
     enabled: true
     access: write
   ingress:
-    enabled: true # this will expose unathenticated alb
+    enabled: true # this will expose unauthenticated alb
   service: {}`</pre>
 
 Apply the `webstack/instance.yaml`
@@ -125,7 +125,7 @@ Expected result:
 
 ### Troubleshoot
 
-If you get the folling error:
+If you get the following error:
 
 ```
 Error connecting to S3:...

--- a/website/docs/examples/aws/deploying-controller.md
+++ b/website/docs/examples/aws/deploying-controller.md
@@ -26,7 +26,7 @@ spec:
         iamRole:
           maxSessionDuration: integer | default=3600
           oidcProvider: string | required=true
-          roleDescription: string | default=IRSA role for ACK EKS controller deployement on EKS cluster using kro Resource group
+          roleDescription: string | default=IRSA role for ACK EKS controller deployment on EKS cluster using kro Resource group
         iamPolicy:
           # would prefer to add a policyDocument here, need to support multiline string here
           description: string | default="policy for eks controller"


### PR DESCRIPTION
Fix typos in Markdown documentation files