### PR TITLE
fix: add missing permissions to create CRDs

### DIFF
--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -74,6 +74,7 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - create
   - get
   - list
   - watch


### PR DESCRIPTION
PROBLEM: KRO service account lacks the necessary permissions to create CustomResourceDefinitions (CRDs) at the cluster scope.

SOLUTION: add the missing `create` verb to apiextensions.k8s.io/customresourcedefinitions

fixes #586 