### PR TITLE
feat: share http client

### DIFF
--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -80,10 +80,6 @@ func NewSet(cfg Config) (*Set, error) {
 func (c *Set) init() error {
 	var err error
 
-	if c.config.UserAgent == "" {
-		c.config.UserAgent = rest.DefaultKubernetesUserAgent()
-	}
-
 	// share http client between all k8s clients
 	sharedHttpClient, err := rest.HTTPClientFor(c.config)
 	if err != nil {

--- a/pkg/client/set.go
+++ b/pkg/client/set.go
@@ -80,17 +80,27 @@ func NewSet(cfg Config) (*Set, error) {
 func (c *Set) init() error {
 	var err error
 
-	c.kubernetes, err = kubernetes.NewForConfig(c.config)
+	if c.config.UserAgent == "" {
+		c.config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// share http client between all k8s clients
+	sharedHttpClient, err := rest.HTTPClientFor(c.config)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+
+	c.kubernetes, err = kubernetes.NewForConfigAndClient(c.config, sharedHttpClient)
 	if err != nil {
 		return err
 	}
 
-	c.dynamic, err = dynamic.NewForConfig(c.config)
+	c.dynamic, err = dynamic.NewForConfigAndClient(c.config, sharedHttpClient)
 	if err != nil {
 		return err
 	}
 
-	c.apiExtensionsV1, err = apiextensionsv1.NewForConfig(c.config)
+	c.apiExtensionsV1, err = apiextensionsv1.NewForConfigAndClient(c.config, sharedHttpClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, all clients create their own http client. 
Sharing a single http client allows these clients to share, among other things, a connection pool which poses a slight performance and memory optimisation.