### PR TITLE
Nested default values in rgd schema

### DIFF
--- a/pkg/simpleschema/transform.go
+++ b/pkg/simpleschema/transform.go
@@ -81,6 +81,7 @@ func (tf *transformer) buildOpenAPISchema(obj map[string]interface{}) (*extv1.JS
 		Type:       "object",
 		Properties: map[string]extv1.JSONSchemaProps{},
 	}
+	childHasDefault := false
 
 	for key, value := range obj {
 		fieldSchema, err := tf.transformField(key, value, schema)
@@ -88,6 +89,13 @@ func (tf *transformer) buildOpenAPISchema(obj map[string]interface{}) (*extv1.JS
 			return nil, err
 		}
 		schema.Properties[key] = *fieldSchema
+		if fieldSchema.Default != nil {
+			childHasDefault = true
+		}
+	}
+
+	if len(schema.Required) == 0 && childHasDefault && schema.Default == nil {
+		schema.Default = &extv1.JSON{Raw: []byte("{}")}
 	}
 
 	return schema, nil

--- a/pkg/simpleschema/transform_test.go
+++ b/pkg/simpleschema/transform_test.go
@@ -66,7 +66,8 @@ func TestBuildOpenAPISchema(t *testing.T) {
 						Default: &extv1.JSON{Raw: []byte("18")},
 					},
 					"contacts": {
-						Type: "object",
+						Type:    "object",
+						Default: &extv1.JSON{Raw: []byte("{}")},
 						Properties: map[string]extv1.JSONSchemaProps{
 							"email": {Type: "string"},
 							"phone": {
@@ -296,7 +297,8 @@ func TestBuildOpenAPISchema(t *testing.T) {
 				},
 			},
 			want: &extv1.JSONSchemaProps{
-				Type: "object",
+				Type:    "object",
+				Default: &extv1.JSON{Raw: []byte("{}")},
 				Properties: map[string]extv1.JSONSchemaProps{
 					"logLevel": {
 						Type:    "string",
@@ -309,7 +311,8 @@ func TestBuildOpenAPISchema(t *testing.T) {
 						},
 					},
 					"features": {
-						Type: "object",
+						Type:    "object",
+						Default: &extv1.JSON{Raw: []byte("{}")},
 						Properties: map[string]extv1.JSONSchemaProps{
 							"logFormat": {
 								Type:    "string",


### PR DESCRIPTION


**NOTE**: Solves the issue [#167](https://github.com/kro-run/kro/issues/167)

## TL;DR

### How to reproduce the issue

*  Run Kro with the code from `main branch` commit `a563cef282f0e0968b0be1465090e3a523c0328a` 

* Deploy RGD from official KRO website, [Deploy Your First ResourceGraphDefinition](https://kro.run/docs/getting-started/deploy-a-resource-graph-definition)

* Deploy the following CR instance:

`instance.yaml`
```yaml
apiVersion: kro.run/v1alpha1
kind: Application
metadata:
  name: my-application-instance
spec:
  name: my-awesome-app
```

It is expected that deployed CR instance has parameter and value `ingress.enabled: false`, as this is default value. However, this parameter is missing in the CR instance.


### How to solve the problem



* Run Kro with the code from `PR`

* cleanup from the test above

```sh
kubectl delete applications my-application-instance
kubectl delete rgd my-application
kubectl delete crd applications.kro.run
```

* Deploy RGD from official KRO website, [Deploy Your First ResourceGraphDefinition](https://kro.run/docs/getting-started/deploy-a-resource-graph-definition)

* Deploy `instance.yaml` from above


As expected, CR instance has parameter and value  `ingress.enabled: false`.


## Longer Explanation


To explain the issue, I will use example from the official KRO website, [Deploy Your First ResourceGraphDefinition](https://kro.run/docs/getting-started/deploy-a-resource-graph-definition)


I have deployed `resourcegraphdefinition.yaml` from that example. As expected, this RGD creates CRD.


Note that there is a default value for `ingress.enabled`:

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: my-application
spec:
  schema:
    apiVersion: v1alpha1
    kind: Application
    spec:
      # Spec fields that users can provide.
      name: string
      image: string | default="nginx"
      ingress:
        enabled: boolean | default=false      # <-----    ingress.enabled has default value
...
```


Then I have deployed modified version of instance.yaml from the same example, where I have removed 2 bottom lines.


`instance.yaml`
```yaml
apiVersion: kro.run/v1alpha1
kind: Application
metadata:
  name: my-application-instance
spec:
  name: my-awesome-app
#  ingress:                <-- this is removed
#    enabled: true         <-- this is removed
```


As parameter `spec.schema.spec.ingress.enabled` from deployed RGD has default value, it is expected that deployed CR instace has parameter `ingress.enabled: false` . However, this is not the case.



Instance my-application-instance looks like following:

```yaml
apiVersion: v1
items:
- apiVersion: kro.run/v1alpha1
  kind: Application
  metadata:
    finalizers:
    - kro.run/finalizer
    generation: 1
    labels:
      kro.run/kro-version: devel
      kro.run/owned: "true"
      kro.run/resource-graph-definition-id: c9bbeea0-43f8-476d-b180-269801951716
      kro.run/resource-graph-definition-name: my-application
    name: my-application-instance
    namespace: default
    resourceVersion: "1366911"
    uid: 9b45dd3f-eb83-4f10-bb44-37d93f278263
  spec:                                             #   <---- missing parameter ingress.enabled in spec
    image: nginx
    name: my-awesome-app
  status:
    availableReplicas: 1
...
```

There is no parameter `ingress.enabled` even if it has default value in CRD (and RGD)


To solve the problem, it is necessary that CRD has default value for the parent parameter of `ingress.enabled` which is `ingress`. As this parameter is object, defaul value should be set to `{}`.

Therefore, in the PR, code checks if there is any child parameter with the default value. If yes, then it sets default for parent param to `{}`.

Exception is when parent has any child parameter which  is set as `required`. In that case it is not necessary to have default value for the parent parameter.



