### PR TITLE
Inconsistency in flect pluralize causing that Kro can't find the CRD

### DIFF
--- a/pkg/metadata/groupversion.go
+++ b/pkg/metadata/groupversion.go
@@ -88,8 +88,7 @@ func GVRtoGVK(gvr schema.GroupVersionResource) schema.GroupVersionKind {
 }
 
 func GVKtoGVR(gvk schema.GroupVersionKind) schema.GroupVersionResource {
-	plural := flect.Pluralize(gvk.Kind)
-	resource := strings.ToLower(plural)
+	resource := flect.Pluralize(strings.ToLower(gvk.Kind))
 	return schema.GroupVersionResource{
 		Group:    gvk.Group,
 		Version:  gvk.Version,


### PR DESCRIPTION
It seems that flect.Pluralize() doesn't always return the same result, depending on it if the passed string is lowercase or not.

When creating a RGD with `spec.schema.kind: ExampleSOS` 

```yaml
apiVersion: kro.run/v1alpha1
kind: ResourceGraphDefinition
metadata:
  name: my-application
spec:
  # kro uses this simple schema to create your CRD schema and apply it
  # The schema defines what users can provide when they instantiate the RGD (create an instance).
  schema:
    apiVersion: v1alpha1
    kind: ExampleSOS
    spec:
      # Spec fields that users can provide.
      name: string
      image: string | default="nginx"
...
```

It appears that flect.Pluralize() returns different result when Kro is [creating CRD](https://github.com/kro-run/kro/blob/main/pkg/graph/crd/crd.go#L39)

and when Kro looks for the [created CRD](https://github.com/kro-run/kro/blob/main/pkg/metadata/groupversion.go#L91-L92)



Therefore Kro throws exception as it can not find the resource examplesoses:

```log
W0708 19:40:45.150168   35461 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.0/tools/cache/reflector.go:243: failed to list kro.run/v1alpha1, Resource=examplesoses: the server could not find the requested resource
2025-07-08T19:40:45.150+0200	ERROR	dynamic-controller	Watch error	{"gvr": "kro.run/v1alpha1, Resource=examplesoses", "error": "failed to list kro.run/v1alpha1, Resource=examplesoses: the server could not find the requested resource"}
github.com/kro-run/kro/pkg/dynamiccontroller.(*DynamicController).StartServingGVK.func3
	/Users/a.babic/Projects/dnabic-c/kro/pkg/dynamiccontroller/dynamic_controller.go:467
...
```


You can also see the behavior here - https://go.dev/play/p/t28eQvqw88t


With other words, it appears that 

```
resource := flect.Pluralize(strings.ToLower(gvk.Kind))
```

is not always the same as 

```
plural := flect.Pluralize(gvk.Kind)
resource := strings.ToLower(plural)
```


