### PR TITLE
[helm] fix: conditionally provide bool args and corrected RBAC for aggregation mode

### DIFF
--- a/helm/templates/cluster-role.yaml
+++ b/helm/templates/cluster-role.yaml
@@ -9,7 +9,7 @@ metadata:
       This ClusterRole grants access for the kro controller.
 
       The kro installation comes with enough for the controller to run, and start watching the relevant resources
-      (e.g. ResourceGraphDefinitions), but in order to allow kro to create and manage other types of resoruces you
+      (e.g. ResourceGraphDefinitions), but in order to allow kro to create and manage other types of resources you
       must manually grant access to those separately.
 
       The easiest way to accomplish this is to create a new ClusterRole with the label `rbac.kro.run/aggregate-to-controller: "true"`
@@ -81,4 +81,35 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -70,8 +70,9 @@ spec:
             - name: KRO_LEADER_ELECTION
               value: {{ .Values.config.enableLeaderElection | quote }}
           args:
+            {{- if .Values.config.allowCRDDeletion }}
             - --allow-crd-deletion
-            - "$(KRO_ALLOW_CRD_DELETION)"
+            {{- end }}
             - --metrics-bind-address
             - "$(KRO_METRICS_BIND_ADDRESS)"
             - --health-probe-bind-address
@@ -92,8 +93,9 @@ spec:
             - "$(KRO_CLIENT_QPS)"
             - --client-burst
             - "$(KRO_CLIENT_BURST)"
+            {{- if .Values.config.enableLeaderElection }}
             - --leader-elect
-            - "$(KRO_LEADER_ELECTION)"
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
For boolean cmd flags, they should only be set when the desired functionality is enabled, otherwise they should be omitted. 
The fix here conditionally sets the below two boolean flags based on the Values provided via helm.
- --allow-crd-deletion
- --leader-elect

**_Note:_** left the environment variable setup unchanged per conversation here where they were added. https://github.com/kro-run/kro/pull/275#discussion_r1951759915

With corrected enabling of leader-election, an RBAC issue arises when running with `mode: aggregation` which is also addressed here. Adds the rules from config [leader_election_role](https://github.com/kro-run/kro/blob/3b37c6b462940a979b2c221ca51f83e3fdf4763a/config/rbac/leader_election_role.yaml#L13) to the helm chart.

Address helm issue: #595 