### PR TITLE
Add base64 encoder to cel expression evaluation

### DIFF
--- a/pkg/cel/ast/inspector.go
+++ b/pkg/cel/ast/inspector.go
@@ -103,6 +103,8 @@ type Inspector struct {
 // knownFunctions contains the list of all CEL functions that are supported
 var knownFunctions = []string{
 	"random.seededString",
+	"base64.decode",
+	"base64.encode",
 }
 
 // DefaultInspector creates a new Inspector instance with the given resources and functions.

--- a/pkg/cel/environment.go
+++ b/pkg/cel/environment.go
@@ -54,6 +54,7 @@ func DefaultEnvironment(options ...EnvOption) (*cel.Env, error) {
 	declarations := []cel.EnvOption{
 		ext.Lists(),
 		ext.Strings(),
+		ext.Encoders(),
 		library.Random(),
 	}
 


### PR DESCRIPTION
This allows to use base64.decode and base64.encode in CEL expressions, useful since reading secrets with externalRef doesn't decode their contents, e.g.:
```yaml
spec:
 resources:  
  - id: readSecret
    externalRef:
      apiVersion: v1
      kind: Secret
      metadata:
        name: mySecret
        namespace: myNs
  - id: res1
    template:
      apiVersion: v1
      kind: ConfigMap
      metadata:
        name: myConfigMap
      data:
        encoded: ${readSecret.data.something}
        decoded: ${string(base64.decode(readSecret.data.something))}
        somethingElseEncoded: ${base64.encode(b'Hello')}
```