### PR TITLE
chore: improve optional type handling and error reporting in GoNativeType

### DIFF
--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -17,7 +17,6 @@ package cel
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -30,28 +29,11 @@ var (
 
 // GoNativeType transforms CEL output into corresponding Go types
 func GoNativeType(v ref.Val) (interface{}, error) {
-	switch v.Type() {
-	case types.BoolType:
-		return v.Value().(bool), nil
-	case types.IntType:
-		return v.Value().(int64), nil
-	case types.UintType:
-		return v.Value().(uint64), nil
-	case types.DoubleType:
-		return v.Value().(float64), nil
-	case types.StringType:
-		return v.Value().(string), nil
-	case types.ListType:
-		return v.ConvertToNative(reflect.TypeOf([]interface{}{}))
-	case types.MapType:
-		return v.ConvertToNative(reflect.TypeOf(map[string]interface{}{}))
-	case types.OptionalType:
-		return v.Value(), nil
-	case types.NullType:
-		return nil, nil
+	switch value := v.Value().(type) {
+	case bool, int64, uint64, float64, string, []interface{}, map[string]interface{}, nil:
+		return value, nil
 	default:
-		// For types we can't convert, return as is with an error
-		return v.Value(), fmt.Errorf("unsupported type: %v", v.Type())
+		return value, fmt.Errorf("unsupported type: %v", v.Type())
 	}
 }
 

--- a/pkg/cel/conversions.go
+++ b/pkg/cel/conversions.go
@@ -33,7 +33,7 @@ func GoNativeType(v ref.Val) (interface{}, error) {
 	case bool, int64, uint64, float64, string, []interface{}, map[string]interface{}, nil:
 		return value, nil
 	default:
-		return value, fmt.Errorf("unsupported type: %v", v.Type())
+		return value, fmt.Errorf("%w: %v", ErrUnsupportedType, v.Type())
 	}
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2521,6 +2521,30 @@ func Test_evaluateExpression(t *testing.T) {
 			expression: "undefined.value",
 			wantErr:    true,
 		},
+		{
+			name: "unsupported type in expression",
+			context: map[string]interface{}{
+				"data": map[string]interface{}{
+					"value": map[int]interface{}{
+						1: "one",
+					},
+				},
+			},
+			expression: "data.value",
+			wantErr:    true,
+		},
+		{
+			name: "unsupported type in optional expression",
+			context: map[string]interface{}{
+				"data": map[string]interface{}{
+					"value": map[int]interface{}{
+						1: "one",
+					},
+				},
+			},
+			expression: "data.?value",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2530,7 +2554,7 @@ func Test_evaluateExpression(t *testing.T) {
 				t.Errorf("evaluateExpression() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if err == nil && got != tt.want {
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("evaluateExpression() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
**Why we need this**
The changes to `GoNativeType()` in https://github.com/kro-run/kro/pull/525 lead to optional values not underlying the same type restrictions as non-optional values. For an optional, a value of type `map[int]interface{}` would be returned, while for a non-optional, it would return an error (see added test cases).
This PR aligns the behaviour of `GoNativeType()` for optional values with non-optional values.

> @a-hilaly is there a particular reason to restrict the allowed types to this set? Otherwise, we might want to think about completely removing `GoNativeTypes()` and replace its calls with `v.Value()` (essentially, only replacing https://github.com/kro-run/kro/blob/6255087b2c49ac2f1542d0366e39d13d9acf054a/pkg/runtime/runtime.go#L586 with `return val.Value(), nil`).

`NullType` values are significantly different (see: https://github.com/kro-run/kro/pull/525#discussion_r2072925272)

