### PR TITLE
Prefer to use interfaces for kube types to allow for unit testing controllers without real kube clients.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/release-utils v0.11.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -103,7 +104,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 tool (

--- a/pkg/client/crd.go
+++ b/pkg/client/crd.go
@@ -50,6 +50,22 @@ type CRDClient interface {
 	Get(ctx context.Context, name string) (*v1.CustomResourceDefinition, error)
 }
 
+// CRDInterface provides a simplified interface for CRD operations
+type CRDInterface interface {
+	// Ensure ensures a CRD exists, up-to-date, and is ready. This can be
+	// a dangerous operation as it will update the CRD if it already exists.
+	//
+	// The caller is responsible for ensuring the CRD, isn't introducing
+	// breaking changes.
+	Ensure(ctx context.Context, crd v1.CustomResourceDefinition) error
+
+	// Get retrieves a CRD by name
+	Get(ctx context.Context, name string) (*v1.CustomResourceDefinition, error)
+
+	// Delete removes a CRD if it exists
+	Delete(ctx context.Context, name string) error
+}
+
 // CRDWrapper provides a simplified interface for CRD operations
 type CRDWrapper struct {
 	client       apiextensionsv1.CustomResourceDefinitionInterface
@@ -57,9 +73,11 @@ type CRDWrapper struct {
 	timeout      time.Duration
 }
 
+var _ CRDInterface = (*CRDWrapper)(nil)
+
 // CRDWrapperConfig contains configuration for the CRD wrapper
 type CRDWrapperConfig struct {
-	Client       *apiextensionsv1.ApiextensionsV1Client
+	Client       apiextensionsv1.ApiextensionsV1Interface
 	PollInterval time.Duration
 	Timeout      time.Duration
 }

--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -1,0 +1,99 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/kro-run/kro/pkg/client"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// FakeSet is a fake implementation of SetInterface for testing
+type FakeSet struct {
+	DynamicClient       dynamic.Interface
+	KubernetesClient    kubernetes.Interface
+	ApiExtensionsClient apiextensionsv1.ApiextensionsV1Interface
+	Config              *rest.Config
+}
+
+var _ client.SetInterface = (*FakeSet)(nil)
+
+// NewFakeSet creates a new FakeSet with the given clients
+func NewFakeSet(dynamicClient dynamic.Interface) *FakeSet {
+	return &FakeSet{
+		DynamicClient: NewJSONSafeDynamicClient(dynamicClient),
+		Config:        &rest.Config{},
+	}
+}
+
+// Kubernetes returns the standard Kubernetes clientset
+func (f *FakeSet) Kubernetes() kubernetes.Interface {
+	return f.KubernetesClient
+}
+
+// Dynamic returns the dynamic client
+func (f *FakeSet) Dynamic() dynamic.Interface {
+	return f.DynamicClient
+}
+
+// APIExtensionsV1 returns the API extensions client
+func (f *FakeSet) APIExtensionsV1() apiextensionsv1.ApiextensionsV1Interface {
+	return f.ApiExtensionsClient
+}
+
+// RESTConfig returns a copy of the underlying REST config
+func (f *FakeSet) RESTConfig() *rest.Config {
+	return f.Config
+}
+
+// CRD returns a new CRD interface instance
+func (f *FakeSet) CRD(cfg client.CRDWrapperConfig) client.CRDInterface {
+	// Return a fake CRD implementation for testing
+	return &FakeCRD{}
+}
+
+// WithImpersonation returns a new client that impersonates the given user
+// For testing, this just returns the same fake client
+func (f *FakeSet) WithImpersonation(user string) (client.SetInterface, error) {
+	return f, nil
+}
+
+// FakeCRD is a fake implementation of CRDInterface for testing
+type FakeCRD struct{}
+
+var _ client.CRDInterface = (*FakeCRD)(nil)
+
+// Ensure ensures a CRD exists, up-to-date, and is ready
+func (f *FakeCRD) Ensure(ctx context.Context, crd v1.CustomResourceDefinition) error {
+	// For testing, just return success
+	return nil
+}
+
+// Get retrieves a CRD by name
+func (f *FakeCRD) Get(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
+	// For testing, return an empty CRD
+	return &v1.CustomResourceDefinition{}, nil
+}
+
+// Delete removes a CRD if it exists
+func (f *FakeCRD) Delete(ctx context.Context, name string) error {
+	// For testing, just return success
+	return nil
+}

--- a/pkg/client/fake/json_safe_client.go
+++ b/pkg/client/fake/json_safe_client.go
@@ -1,0 +1,210 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// JSONSafeDynamicClient wraps a fake dynamic client and performs JSON marshal/unmarshal
+// to sanitize data before passing it to the underlying client, preventing deep copy issues
+// with pointer fields
+type JSONSafeDynamicClient struct {
+	client dynamic.Interface
+}
+
+// NewJSONSafeDynamicClient creates a new JSON-safe wrapper around a dynamic client
+func NewJSONSafeDynamicClient(client dynamic.Interface) *JSONSafeDynamicClient {
+	return &JSONSafeDynamicClient{
+		client: client,
+	}
+}
+
+// Resource returns a resource interface for the given resource
+func (j *JSONSafeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &jsonSafeNamespaceableResourceInterface{
+		resource: j.client.Resource(resource),
+	}
+}
+
+// jsonSafeNamespaceableResourceInterface wraps a NamespaceableResourceInterface
+type jsonSafeNamespaceableResourceInterface struct {
+	resource dynamic.NamespaceableResourceInterface
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Namespace(namespace string) dynamic.ResourceInterface {
+	return &jsonSafeResourceInterface{
+		resource: j.resource.Namespace(namespace),
+	}
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Create(ctx, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Update(ctx, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.UpdateStatus(ctx, sanitized, options)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return j.resource.Delete(ctx, name, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return j.resource.DeleteCollection(ctx, options, listOptions)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return j.resource.Get(ctx, name, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return j.resource.List(ctx, opts)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return j.resource.Watch(ctx, opts)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return j.resource.Patch(ctx, name, pt, data, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Apply(ctx, name, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeNamespaceableResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.ApplyStatus(ctx, name, sanitized, options)
+}
+
+// jsonSafeResourceInterface wraps a ResourceInterface (for namespaced resources)
+type jsonSafeResourceInterface struct {
+	resource dynamic.ResourceInterface
+}
+
+func (j *jsonSafeResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Create(ctx, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Update(ctx, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.UpdateStatus(ctx, sanitized, options)
+}
+
+func (j *jsonSafeResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return j.resource.Delete(ctx, name, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return j.resource.DeleteCollection(ctx, options, listOptions)
+}
+
+func (j *jsonSafeResourceInterface) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return j.resource.Get(ctx, name, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return j.resource.List(ctx, opts)
+}
+
+func (j *jsonSafeResourceInterface) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return j.resource.Watch(ctx, opts)
+}
+
+func (j *jsonSafeResourceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return j.resource.Patch(ctx, name, pt, data, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.Apply(ctx, name, sanitized, options, subresources...)
+}
+
+func (j *jsonSafeResourceInterface) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	sanitized, err := sanitizeUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return j.resource.ApplyStatus(ctx, name, sanitized, options)
+}
+
+// sanitizeUnstructured performs JSON marshal/unmarshal to sanitize unstructured data
+// This removes pointer references and makes the data safe for fake client deep copying
+func sanitizeUnstructured(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	// Marshal to JSON
+	jsonData, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal back to unstructured
+	var sanitized unstructured.Unstructured
+	if err := json.Unmarshal(jsonData, &sanitized); err != nil {
+		return nil, err
+	}
+
+	return &sanitized, nil
+}

--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -76,7 +76,7 @@ type Controller struct {
 	// this controller is responsible for.
 	gvr schema.GroupVersionResource
 	// client holds the dynamic client to use for interacting with the Kubernetes API.
-	clientSet *kroclient.Set
+	clientSet kroclient.SetInterface
 	// rgd is a read-only reference to the Graph that the controller is
 	// managing instances for.
 	// TODO: use a read-only interface for the ResourceGraphDefinition
@@ -97,7 +97,7 @@ func NewController(
 	reconcileConfig ReconcileConfig,
 	gvr schema.GroupVersionResource,
 	rgd *graph.Graph,
-	clientSet *kroclient.Set,
+	clientSet kroclient.SetInterface,
 	defaultServiceAccounts map[string]string,
 	instanceLabeler metadata.Labeler,
 ) *Controller {

--- a/pkg/controller/resourcegraphdefinition/controller.go
+++ b/pkg/controller/resourcegraphdefinition/controller.go
@@ -50,7 +50,7 @@ type ResourceGraphDefinitionReconciler struct {
 	client.Client
 	instanceLogger logr.Logger
 
-	clientSet  *kroclient.Set
+	clientSet  kroclient.SetInterface
 	crdManager kroclient.CRDClient
 
 	metadataLabeler         metadata.Labeler
@@ -60,7 +60,7 @@ type ResourceGraphDefinitionReconciler struct {
 }
 
 func NewResourceGraphDefinitionReconciler(
-	clientSet *kroclient.Set,
+	clientSet kroclient.SetInterface,
 	allowCRDDeletion bool,
 	dynamicController *dynamiccontroller.DynamicController,
 	builder *graph.Builder,
@@ -121,7 +121,7 @@ func (r *ResourceGraphDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) e
 				},
 			}),
 		).
-		Complete(reconcile.AsReconciler(mgr.GetClient(), r))
+		Complete(reconcile.AsReconciler[*v1alpha1.ResourceGraphDefinition](mgr.GetClient(), r))
 }
 
 // findRGDsForCRD returns a list of reconcile requests for the ResourceGraphDefinition


### PR DESCRIPTION
Working on https://github.com/kro-run/kro/pull/622 I get a wall where I need to unit test some things but found that kro is storing the real kubeclient structs in controllers rather than interfaces. 

Don't store real kube structs, only interface types. It makes testing possible.