### PR TITLE
Have separate instance labellers for different reconcile paths.

### DIFF
--- a/pkg/controller/instance/controller.go
+++ b/pkg/controller/instance/controller.go
@@ -84,6 +84,9 @@ type Controller struct {
 	// instanceLabeler is responsible for applying consistent labels
 	// to resources managed by this controller.
 	instanceLabeler metadata.Labeler
+	// sourceLabeler is responsible for applying source labels
+	// to instance managed by this controller.
+	sourceLabeler metadata.Labeler
 	// reconcileConfig holds the configuration parameters for the reconciliation
 	// process.
 	reconcileConfig ReconcileConfig
@@ -100,6 +103,7 @@ func NewController(
 	clientSet kroclient.SetInterface,
 	defaultServiceAccounts map[string]string,
 	instanceLabeler metadata.Labeler,
+	sourceLabeler metadata.Labeler,
 ) *Controller {
 	return &Controller{
 		log:                    log,
@@ -107,6 +111,7 @@ func NewController(
 		clientSet:              clientSet,
 		rgd:                    rgd,
 		instanceLabeler:        instanceLabeler,
+		sourceLabeler:          sourceLabeler,
 		reconcileConfig:        reconcileConfig,
 		defaultServiceAccounts: defaultServiceAccounts,
 	}
@@ -155,7 +160,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) error {
 		gvr:                         c.gvr,
 		client:                      executionClient,
 		runtime:                     rgRuntime,
-		instanceLabeler:             c.instanceLabeler,
+		instanceLabeler:             c.sourceLabeler,
 		instanceSubResourcesLabeler: instanceSubResourcesLabeler,
 		reconcileConfig:             c.reconcileConfig,
 		// Fresh instance state at each reconciliation loop.

--- a/pkg/controller/resourcegraphdefinition/controller_reconcile.go
+++ b/pkg/controller/resourcegraphdefinition/controller_reconcile.go
@@ -48,13 +48,14 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(ctx
 	mark.ResourceGraphValid()
 
 	// Setup metadata labeling
-	graphExecLabeler, err := r.setupLabeler(rgd)
+	graphExecLabeler, sourceLabeler, err := r.setupLabeler(rgd)
 	if err != nil {
 		mark.FailedLabelerSetup(err.Error())
 		return nil, nil, fmt.Errorf("failed to setup labeler: %w", err)
 	}
 
 	crd := processedRGD.Instance.GetCRD()
+	// TODO(barney-s): should we apply the source labeler to the crd here instead ?
 	graphExecLabeler.ApplyLabels(&crd.ObjectMeta)
 
 	// Ensure CRD exists and is up to date
@@ -71,7 +72,7 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(ctx
 
 	// Setup and start microcontroller
 	gvr := processedRGD.Instance.GetGroupVersionResource()
-	controller := r.setupMicroController(gvr, processedRGD, rgd.Spec.DefaultServiceAccounts, graphExecLabeler)
+	controller := r.setupMicroController(gvr, processedRGD, rgd.Spec.DefaultServiceAccounts, graphExecLabeler, sourceLabeler)
 
 	log.V(1).Info("reconciling resource graph definition micro controller")
 	// TODO: the context that is passed here is tied to the reconciliation of the rgd, we might need to make
@@ -87,9 +88,23 @@ func (r *ResourceGraphDefinitionReconciler) reconcileResourceGraphDefinition(ctx
 }
 
 // setupLabeler creates and merges the required labelers for the resource graph definition
-func (r *ResourceGraphDefinitionReconciler) setupLabeler(rgd *v1alpha1.ResourceGraphDefinition) (metadata.Labeler, error) {
+func (r *ResourceGraphDefinitionReconciler) setupLabeler(rgd *v1alpha1.ResourceGraphDefinition) (metadata.Labeler, metadata.Labeler, error) {
+	var err error
+	// Setup metadata labeling
 	rgLabeler := metadata.NewResourceGraphDefinitionLabeler(rgd)
-	return r.metadataLabeler.Merge(rgLabeler)
+	rgSourceLabeler := metadata.NewResourceGraphDefinitionSourceLabeler(rgd)
+
+	mergedLabeler, err := r.metadataLabeler.Merge(rgLabeler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mergedSourceLabeler, err := r.metadataLabeler.Merge(rgSourceLabeler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mergedLabeler, mergedSourceLabeler, nil
 }
 
 // setupMicroController creates a new controller instance with the required configuration
@@ -98,6 +113,7 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 	processedRGD *graph.Graph,
 	defaultSVCs map[string]string,
 	labeler metadata.Labeler,
+	sourceLabeler metadata.Labeler,
 ) *instancectrl.Controller {
 	instanceLogger := r.instanceLogger.WithName(fmt.Sprintf("%s-controller", gvr.Resource)).WithValues(
 		"controller", gvr.Resource,
@@ -117,6 +133,7 @@ func (r *ResourceGraphDefinitionReconciler) setupMicroController(
 		r.clientSet,
 		defaultSVCs,
 		labeler,
+		sourceLabeler,
 	)
 }
 

--- a/pkg/metadata/labels.go
+++ b/pkg/metadata/labels.go
@@ -41,10 +41,17 @@ const (
 	InstanceLabel          = LabelKROPrefix + "instance-name"
 	InstanceNamespaceLabel = LabelKROPrefix + "instance-namespace"
 
+	// Parent Identifier Labels. These are set by the instance reconciler that creates/updates the resource.
 	ResourceGraphDefinitionIDLabel        = LabelKROPrefix + "resource-graph-definition-id"
 	ResourceGraphDefinitionNameLabel      = LabelKROPrefix + "resource-graph-definition-name"
 	ResourceGraphDefinitionNamespaceLabel = LabelKROPrefix + "resource-graph-definition-namespace"
 	ResourceGraphDefinitionVersionLabel   = LabelKROPrefix + "resource-graph-definition-version"
+
+	// Source Identifier Labels. These are set by the instance reconciler that reconciles the resource.
+	SourceResourceGraphDefinitionIDLabel        = LabelKROPrefix + "source-resource-graph-definition-id"
+	SourceResourceGraphDefinitionNameLabel      = LabelKROPrefix + "source-resource-graph-definition-name"
+	SourceResourceGraphDefinitionNamespaceLabel = LabelKROPrefix + "source-resource-graph-definition-namespace"
+	SourceResourceGraphDefinitionVersionLabel   = LabelKROPrefix + "source-resource-graph-definition-version"
 )
 
 // IsKROOwned returns true if the resource is owned by KRO.
@@ -121,6 +128,15 @@ func NewResourceGraphDefinitionLabeler(rgMeta metav1.Object) GenericLabeler {
 	return map[string]string{
 		ResourceGraphDefinitionIDLabel:   string(rgMeta.GetUID()),
 		ResourceGraphDefinitionNameLabel: rgMeta.GetName(),
+	}
+}
+
+// NewResourceGraphDefinitionSourceLabeler returns a new labeler that sets the
+// SourceResourceGraphDefinitionLabel and SourceResourceGraphDefinitionIDLabel labels on a resource.
+func NewResourceGraphDefinitionSourceLabeler(rgMeta metav1.Object) GenericLabeler {
+	return map[string]string{
+		SourceResourceGraphDefinitionIDLabel:   string(rgMeta.GetUID()),
+		SourceResourceGraphDefinitionNameLabel: rgMeta.GetName(),
 	}
 }
 

--- a/test/e2e/chainsaw/check-multi-resource-rgd/instance-create-assert.yaml
+++ b/test/e2e/chainsaw/check-multi-resource-rgd/instance-create-assert.yaml
@@ -6,7 +6,7 @@ metadata:
   generation: 1
   labels:
     kro.run/owned: "true"
-    kro.run/resource-graph-definition-name: check-multi-resource-rgd
+    kro.run/source-resource-graph-definition-name: check-multi-resource-rgd
   name: test-app-instance
 spec:
   image: nginx:1.24


### PR DESCRIPTION
This is needed when we have RGD2 instance in RGD1 resources. Today both paths use the same label resulting in conflict.

path 1: RGD2.instance created as part of an RGD1 instance reconciliation
path 2: RGD2.instance reconciled by RGD2 reconciler