### PR TITLE
update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,11 @@
 The current Maintainers Group for the kro project consists of:
 
-| Name                                                    | Employer  | Responsibilities |
-|---------------------------------------------------------|-----------|-------------------|
-| [@a-hilaly](https://github.com/a-hilaly)                | AWS       |                   |
-| [@barney-s](https://github.com/barney-s)                | Google    |                   |
-| [@bridgetkromhout](https://github.com/bridgetkromhout)  | Microsoft |                   |
-| [@cheftako](https://github.com/cheftako)                | Google    |                   |
-| [@jlbutler](https://github.com/jlbutler)                | AWS       |                   |
-| [@matthchr](https://github.com/matthchr)                | Microsoft |                   |
-| [@nicslatts](https://github.com/nicslatts)              | Google    |                   |
-| [@rynowak](https://github.com/rynowak)                  | Microsoft |                   |
-| [@eqe-aws](https://github.com/eqe-aws)                  | AWS       |                   |
+| Name                                                    | Employer    | Responsibilities |
+|---------------------------------------------------------|-------------|-------------------|
+| [@a-hilaly](https://github.com/a-hilaly)                | AWS         |                   |
+| [@barney-s](https://github.com/barney-s)                | Google      |                   |
+| [@bridgetkromhout](https://github.com/bridgetkromhout)  | Microsoft   |                   |
+| [@cheftako](https://github.com/cheftako)                | Google      |                   |
+| [@jlbutler](https://github.com/jlbutler)                | AWS         |                   |
+| [@matthchr](https://github.com/matthchr)                | Microsoft   |                   |
+| [@nicslatts](https://github.com/nicslatts)              | Astronomer  |                   |


### PR DESCRIPTION
Updating our maintainers list, deferred maintenance. 

* Ryan has moved on to other focus areas (thank you Ryan!)
* Ed has moved on to another role and focus area (thank you Ed!)
* Nic has changed employers and remains with us (thanks Nic!)

This resolves to equal burden across founding CSPs, and sets a precedent for a non-founder organization to attain and/or hold maintainer roles.

Handling this in a single PR as its mostly housekeeping - but let's please have at least 2 mandatory LGTM to merge. 