### PR TITLE
Adding emeritus; removing empty column

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,11 +1,16 @@
 The current Maintainers Group for the kro project consists of:
 
-| Name                                                    | Employer    | Responsibilities |
-|---------------------------------------------------------|-------------|-------------------|
-| [@a-hilaly](https://github.com/a-hilaly)                | AWS         |                   |
-| [@barney-s](https://github.com/barney-s)                | Google      |                   |
-| [@bridgetkromhout](https://github.com/bridgetkromhout)  | Microsoft   |                   |
-| [@cheftako](https://github.com/cheftako)                | Google      |                   |
-| [@jlbutler](https://github.com/jlbutler)                | AWS         |                   |
-| [@matthchr](https://github.com/matthchr)                | Microsoft   |                   |
-| [@nicslatts](https://github.com/nicslatts)              | Astronomer  |                   |
+| Name                                                    | Employer    |
+|---------------------------------------------------------|-------------|
+| [@a-hilaly](https://github.com/a-hilaly)                | AWS         |
+| [@barney-s](https://github.com/barney-s)                | Google      |
+| [@bridgetkromhout](https://github.com/bridgetkromhout)  | Microsoft   |
+| [@cheftako](https://github.com/cheftako)                | Google      |
+| [@jlbutler](https://github.com/jlbutler)                | AWS         |
+| [@matthchr](https://github.com/matthchr)                | Microsoft   |
+| [@nicslatts](https://github.com/nicslatts)              | Astronomer  |
+
+Emeritus maintainers:
+
+[@eqe-aws](https://github.com/eqe-aws)
+[@rynowak](https://github.com/rynowak)


### PR DESCRIPTION
Thanks to @jlbutler for the update in https://github.com/kro-run/kro/pull/641. I'm offering these additional changes:

- As discussed in the previous PR, listing past maintainers as emeritus.
- Removing unused column as it only adds confusion due to being empty.