### PR TITLE
Remove some defaulting fields in deployment spec for tests

### DIFF
--- a/test/e2e/chainsaw/check-instance-update/deployment-update-assert.yaml
+++ b/test/e2e/chainsaw/check-instance-update/deployment-update-assert.yaml
@@ -16,7 +16,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: test-instance
     spec:
@@ -24,12 +23,10 @@ spec:
       - image: nginx:1.25
         imagePullPolicy: IfNotPresent
         name: main
-        resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 30
 


### PR DESCRIPTION
 Recently k8s removed the defaulting for creationTimestamp.

https://github.com/kubernetes/kubernetes/pull/130989

This defaulting change percolated to kind version 1.30 in our tests and caused the test breakage