### PR TITLE
api: add AdditionalPrinterColumnPolicy and merge logic for additional…

### DIFF
--- a/api/v1alpha1/resourcegraphdefinition_types.go
+++ b/api/v1alpha1/resourcegraphdefinition_types.go
@@ -19,10 +19,14 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
+type AdditionalPrinterColumnPolicy string
+
 const (
 	// DefaultServiceAccountKey is the key to use for the default service account
 	// in the serviceAccounts map.
 	DefaultServiceAccountKey = "*"
+	AdditionalPrinterColumnPolicyReplace AdditionalPrinterColumnPolicy = "Replace"
+	AdditionalPrinterColumnPolicyAdd     AdditionalPrinterColumnPolicy = "Add"
 )
 
 // ResourceGraphDefinitionSpec defines the desired state of ResourceGraphDefinition
@@ -86,11 +90,24 @@ type Schema struct {
 	// Validation is a list of validation rules that are applied to the
 	// resourcegraphdefinition.
 	Validation []Validation `json:"validation,omitempty"`
-	// AdditionalPrinterColumns defines additional printer columns
-	// that will be passed down to the created CRD. If set, no
-	// default printer columns will be added to the created CRD,
-	// and if default printer columns need to be retained, they
-	// need to be added explicitly.
+	// AdditionalPrinterColumnPolicy defines additional printer columns
+	// that will be passed down to the created CRD. The Default tag is "Replace", that only uses the provided columns, "Add:" tag Merge provided columns with defaults.
+	//
+	// AdditionalPrinterColumnPolicy controls how provided additional printer
+	// columns are applied to the generated CRD.
+	//
+	// - "Replace": only use the provided columns; if none are provided, fall
+	//   back to the operator defaults (backwards compatible default).
+	// - "Add": merge the provided columns with the defaults, with user
+	//   definitions overriding defaults when they share a identifying key
+	//   (Name preferred, fallback to JSONPath).
+	//
+	// +kubebuilder:validation:Enum=Replace;Add
+	// +kubebuilder:default=Replace
+	AdditionalPrinterColumnPolicy AdditionalPrinterColumnPolicy `json:"additionalPrinterColumnPolicy,omitempty"`
+
+	// AdditionalPrinterColumns is the list of user-specified printer columns
+	// to apply according to AdditionalPrinterColumnPolicy.
 	//
 	// +kubebuilder:validation:Optional
 	AdditionalPrinterColumns []extv1.CustomResourceColumnDefinition `json:"additionalPrinterColumns,omitempty"`

--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -482,7 +482,7 @@ func (b *Builder) buildInstanceResource(
 
 	// Synthesize the CRD for the instance resource.
 	overrideStatusFields := true
-	instanceCRD := crd.SynthesizeCRD(group, apiVersion, kind, *instanceSpecSchema, *instanceStatusSchema, overrideStatusFields, rgDefinition.AdditionalPrinterColumns)
+	instanceCRD := crd.SynthesizeCRD(group, apiVersion, kind, *instanceSpecSchema, *instanceStatusSchema, overrideStatusFields, rgDefinition.AdditionalPrinterColumnPolicy, rgDefinition.AdditionalPrinterColumns)
 
 	// Emulate the CRD
 	instanceSchemaExt := instanceCRD.Spec.Versions[0].Schema.OpenAPIV3Schema

--- a/pkg/graph/crd/crd.go
+++ b/pkg/graph/crd/crd.go
@@ -27,12 +27,13 @@ import (
 
 // SynthesizeCRD generates a CustomResourceDefinition for a given API version and kind
 // with the provided spec and status schemas~
-func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool, additionalPrinterColumns []extv1.CustomResourceColumnDefinition) *extv1.CustomResourceDefinition {
+func SynthesizeCRD(group, apiVersion, kind string, spec, status extv1.JSONSchemaProps, statusFieldsOverride bool, policy v1alpha1.AdditionalPrinterColumnPolicy, additionalPrinterColumns []extv1.CustomResourceColumnDefinition) *extv1.CustomResourceDefinition {
 	crdGroup := group
 	if crdGroup == "" {
 		crdGroup = v1alpha1.KRODomainName
 	}
-	return newCRD(crdGroup, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride), additionalPrinterColumns)
+	merged := newCRDAdditionalPrinterColumns(policy, additionalPrinterColumns)
+	return newCRD(crdGroup, apiVersion, kind, newCRDSchema(spec, status, statusFieldsOverride), merged)
 }
 
 func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps, additionalPrinterColumns []extv1.CustomResourceColumnDefinition) *extv1.CustomResourceDefinition {
@@ -62,7 +63,7 @@ func newCRD(group, apiVersion, kind string, schema *extv1.JSONSchemaProps, addit
 					Subresources: &extv1.CustomResourceSubresources{
 						Status: &extv1.CustomResourceSubresourceStatus{},
 					},
-					AdditionalPrinterColumns: newCRDAdditionalPrinterColumns(additionalPrinterColumns),
+					AdditionalPrinterColumns: newCRDAdditionalPrinterColumns(v1alpha1.AdditionalPrinterColumnPolicyReplace, additionalPrinterColumns),
 				},
 			},
 		},
@@ -103,10 +104,42 @@ func newCRDSchema(spec, status extv1.JSONSchemaProps, statusFieldsOverride bool)
 	}
 }
 
-func newCRDAdditionalPrinterColumns(additionalPrinterColumns []extv1.CustomResourceColumnDefinition) []extv1.CustomResourceColumnDefinition {
-	if len(additionalPrinterColumns) == 0 {
-		return defaultAdditionalPrinterColumns
+func newCRDAdditionalPrinterColumns(policy v1alpha1.AdditionalPrinterColumnPolicy, userCols []extv1.CustomResourceColumnDefinition) []extv1.CustomResourceColumnDefinition {
+	// Default behavior: Replace
+	if policy == "" || policy == v1alpha1.AdditionalPrinterColumnPolicyReplace {
+		if len(userCols) == 0 {
+			return defaultAdditionalPrinterColumns
+		}
+		return userCols
 	}
 
-	return additionalPrinterColumns
+	// Add behavior: merge defaults with user-provided columns.
+	keyOf := func(c extv1.CustomResourceColumnDefinition) string {
+		if c.Name != "" {
+			return "name:" + c.Name
+		}
+		if c.JSONPath != "" {
+			return "path:" + c.JSONPath
+		}
+		// fallback to a stable placeholder the pointer value
+		return fmt.Sprintf("idx:%p", &c)
+	}
+
+	merged := make([]extv1.CustomResourceColumnDefinition, 0, len(defaultAdditionalPrinterColumns))
+	index := map[string]int{}
+	for i, d := range defaultAdditionalPrinterColumns {
+		merged = append(merged, d)
+		index[keyOf(d)] = i
+	}
+
+	for _, u := range userCols {
+		k := keyOf(u)
+		if pos, ok := index[k]; ok {
+			merged[pos] = u
+		} else {
+			index[k] = len(merged)
+			merged = append(merged, u)
+		}
+	}
+	return merged
 }

--- a/pkg/graph/crd/crd_test.go
+++ b/pkg/graph/crd/crd_test.go
@@ -73,7 +73,7 @@ func TestSynthesizeCRD(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			crd := SynthesizeCRD(tt.group, tt.apiVersion, tt.kind, tt.spec, tt.status, tt.statusFieldsOverride, nil)
+			crd := SynthesizeCRD(tt.group, tt.apiVersion, tt.kind, tt.spec, tt.status, tt.statusFieldsOverride, v1alpha1.AdditionalPrinterColumnPolicyReplace, nil)
 
 			assert.Equal(t, tt.expectedName, crd.Name)
 			assert.Equal(t, tt.expectedGroup, crd.Spec.Group)


### PR DESCRIPTION
… printer columns

### API change

- Added a new string type AdditionalPrinterColumnPolicy with two values: "Replace" and "Add".
- The field is exposed on Schema as AdditionalPrinterColumnPolicy and annotated so the CRD OpenAPI schema contains enum + default ("Replace").

###What the policy does (simple)

- Replace (default): use the user-provided additionalPrinterColumns exactly. If the user provided none, fall back to the existing built-in default columns (preserves current behavior).
- Add: start from the default columns, then apply user columns: if a user column matches a default (by Name, otherwise by JSONPath) it replaces that default; otherwise the user column is appended.
###Backwards compatibility

- If the policy is omitted or unknown, code treats it as Replace so existing objects and behavior remain unchanged.
- Merge key / anonymous columns

1. Matching uses Name first, JSONPath second.

2. For columns with neither Name nor JSONPath the current code uses a provisional fallback key (pointer-based placeholder). This is not stable across runs; recommend choosing one:
use the default slice index as a stable fallback key, 