### PR TITLE
kro cli publish command

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -27,13 +27,16 @@ License version 2.0, we include the full text of the package's License below.
 * `github.com/google/go-cmp`
 * `github.com/onsi/ginkgo/v2`
 * `github.com/onsi/gomega`
+* `github.com/opencontainers/image-spec`
 * `github.com/prometheus/client_golang`
 * `github.com/spf13/cobra`
 * `github.com/stretchr/testify`
 * `go.uber.org/zap`
 * `golang.org/x/exp`
+* `golang.org/x/term`
 * `golang.org/x/time`
 * `google.golang.org/genproto/googleapis/api`
+* `gopkg.in/yaml.v2`
 * `k8s.io/api`
 * `k8s.io/apiextensions-apiserver`
 * `k8s.io/apimachinery`
@@ -41,6 +44,7 @@ License version 2.0, we include the full text of the package's License below.
 * `k8s.io/client-go`
 * `k8s.io/kube-openapi`
 * `k8s.io/utils`
+* `oras.land/oras-go/v2`
 * `sigs.k8s.io/controller-runtime`
 * `sigs.k8s.io/release-utils`
 * `sigs.k8s.io/yaml`
@@ -950,6 +954,56 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+### github.com/opencontainers/image-spec
+
+License Identifier: Apache-2.0
+
+Subdependencies:
+* `github.com/opencontainers/go-digest`
+* `github.com/russross/blackfriday`
+* `github.com/santhosh-tekuri/jsonschema/v5`
+
+#### github.com/opencontainers/go-digest
+
+License Identifier: Apache-2.0
+
+#### github.com/russross/blackfriday
+
+License Identifier: BSD-2-Clause
+
+Blackfriday is distributed under the Simplified BSD License:
+
+Copyright © 2011 Russ Ross
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided with
+    the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#### github.com/santhosh-tekuri/jsonschema/v5
+
+License Identifier: Apache-2.0
+
 ### github.com/prometheus/client_golang
 
 License Identifier: Apache-2.0
@@ -1453,6 +1507,42 @@ THE SOFTWARE.
 
 
 
+### golang.org/x/term
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Subdependencies:
+* `golang.org/x/sys`
+
 ### golang.org/x/time
 
 License Identifier: BSD-3-Clause
@@ -1484,6 +1574,8 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 
 
 
@@ -3246,7 +3338,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License Identifier: BSD-3-Clause
 
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -3258,7 +3350,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
@@ -3280,7 +3372,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License Identifier: BSD-3-Clause
 
-Copyright 2009 The Go Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -3292,7 +3384,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google LLC nor the names of its
+   * Neither the name of Google Inc. nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
@@ -3485,69 +3577,14 @@ License Identifier: Apache-2.0
 
 
 
+### oras.land/oras-go/v2
 
+License Identifier: Apache-2.0
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### golang.org/x/sync
-
-License Identifier: BSD-3-Clause
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
+Subdependencies:
+* `github.com/opencontainers/go-digest`
+* `github.com/opencontainers/image-spec`
+* `golang.org/x/sync`
 
 ### sigs.k8s.io/controller-runtime
 
@@ -3988,43 +4025,5 @@ THE SOFTWARE.
 #### github.com/magefile/mage
 
 License Identifier: Apache-2.0
-
-
-
-
-
-
-
-#### golang.org/x/sync
-
-License Identifier: BSD-3-Clause
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 

--- a/cmd/kro/commands/publish/publish.go
+++ b/cmd/kro/commands/publish/publish.go
@@ -1,0 +1,244 @@
+// Copyright 2025 The Kube Resource Orchestrator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"archive/tar"
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+type PublishConfig struct {
+	ociTarballPath string
+	remoteRef      string
+	username       string
+	password       string
+}
+
+var publishConfig = &PublishConfig{}
+
+func init() {
+	publishCmd.PersistentFlags().StringVarP(&publishConfig.ociTarballPath,
+		"file", "f", "",
+		"Path to the OCI image tarball created by the 'package' command",
+	)
+	publishCmd.PersistentFlags().StringVarP(&publishConfig.remoteRef,
+		"ref", "r", "",
+		"Remote reference to publish the OCI image to (e.g., 'ghcr.io/user/repo:tag')",
+	)
+	publishCmd.PersistentFlags().StringVarP(&publishConfig.username,
+		"username", "u", "",
+		"Username for the remote registry",
+	)
+	publishCmd.PersistentFlags().StringVarP(&publishConfig.password,
+		"password", "p", "",
+		"Password for the remote registry",
+	)
+}
+
+var publishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Publish a packaged OCI image to a remote registry",
+	Long: "The publish command takes an OCI image tarball, created by the 'package' command, " +
+		"and pushes it to a specified container registry.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if publishConfig.ociTarballPath == "" {
+			return fmt.Errorf("path to the OCI tarball is required, please use the --file flag")
+		}
+
+		if publishConfig.remoteRef == "" {
+			return fmt.Errorf("remote reference is required, please use the --ref flag")
+		}
+
+		if publishConfig.username == "" {
+			fmt.Print("Username: ")
+			reader := bufio.NewReader(os.Stdin)
+			username, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("failed to read username: %w", err)
+			}
+			publishConfig.username = strings.TrimSpace(username)
+		}
+
+		if publishConfig.password == "" {
+			fmt.Print("Password: ")
+			bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+			fmt.Println()
+			if err != nil {
+				return fmt.Errorf("failed to read password: %w", err)
+			}
+			publishConfig.password = string(bytePassword)
+		}
+
+		tempDir, err := os.MkdirTemp("", "kro-publish-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp dir: %w", err)
+		}
+		defer func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				fmt.Printf("Warning: failed to remove temp dir %s: %v\n", tempDir, err)
+			}
+		}()
+
+		fmt.Printf("Extracting %s to %s...\n", publishConfig.ociTarballPath, tempDir)
+		if err := untar(publishConfig.ociTarballPath, tempDir); err != nil {
+			return fmt.Errorf("failed to extract OCI tarball: %w", err)
+		}
+
+		store, err := oci.New(tempDir)
+		if err != nil {
+			return fmt.Errorf("failed to open OCI layout at %s: %w", tempDir, err)
+		}
+
+		rootDesc, err := findRootManifestDescriptor(tempDir)
+		if err != nil {
+			return fmt.Errorf("failed to find root manifest in OCI layout: %w", err)
+		}
+		fmt.Printf("Found manifest to push: %s\n", rootDesc.Digest)
+
+		ctx := context.Background()
+		repo, err := remote.NewRepository(publishConfig.remoteRef)
+		if err != nil {
+			return fmt.Errorf("failed to create remote repository for %s: %w", publishConfig.remoteRef, err)
+		}
+
+		if publishConfig.username != "" && publishConfig.password != "" {
+			fmt.Println("Using provided username/password for authentication")
+
+			credentialFunc := func(ctx context.Context, registry string) (auth.Credential, error) {
+				return auth.Credential{
+					Username: publishConfig.username,
+					Password: publishConfig.password,
+				}, nil
+			}
+
+			repo.Client = &auth.Client{
+				Client:     retry.DefaultClient,
+				Cache:      auth.NewCache(),
+				Credential: credentialFunc,
+			}
+		} else {
+			fmt.Println("No credentials provided, attempting anonymous access")
+			repo.Client = &auth.Client{
+				Client: retry.DefaultClient,
+				Cache:  auth.NewCache(),
+				Credential: auth.StaticCredential(publishConfig.remoteRef, auth.Credential{
+					Username: publishConfig.username,
+					Password: publishConfig.password,
+				})}
+		}
+
+		fmt.Printf("Publishing to %s...\n", publishConfig.remoteRef)
+		_, err = oras.Copy(ctx, store, rootDesc.Digest.String(), repo, publishConfig.remoteRef, oras.DefaultCopyOptions)
+		if err != nil {
+			return fmt.Errorf("failed to publish OCI image: %w", err)
+		}
+
+		fmt.Println("Successfully published OCI image to", publishConfig.remoteRef)
+		return nil
+	},
+}
+
+func untar(tarballPath, destDir string) error {
+	file, err := os.Open(tarballPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Println("failed to close tarball")
+		}
+	}()
+
+	tr := tar.NewReader(file)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(destDir, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			outFile, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(outFile, tr); err != nil {
+				cerr := outFile.Close()
+				if cerr != nil {
+					fmt.Println("failed to close file:", cerr)
+				}
+				return err
+			}
+			if err := outFile.Close(); err != nil {
+				fmt.Println("failed to close file:", err)
+			}
+		default:
+			return fmt.Errorf("unsupported file type in tar: %c for file %s", header.Typeflag, header.Name)
+		}
+	}
+	return nil
+}
+
+func findRootManifestDescriptor(layoutPath string) (ocispec.Descriptor, error) {
+	indexPath := filepath.Join(layoutPath, "index.json")
+	indexBytes, err := os.ReadFile(indexPath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("could not read index.json: %w", err)
+	}
+
+	var index ocispec.Index
+	if err := json.Unmarshal(indexBytes, &index); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("could not unmarshal index.json: %w", err)
+	}
+
+	if len(index.Manifests) == 0 {
+		return ocispec.Descriptor{}, fmt.Errorf("no manifests found in index.json")
+	}
+
+	return index.Manifests[0], nil
+}
+
+func AddPublishCommand(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(publishCmd)
+}

--- a/cmd/kro/commands/root.go
+++ b/cmd/kro/commands/root.go
@@ -18,10 +18,12 @@ import (
 	"github.com/spf13/cobra"
 
 	generate "github.com/kro-run/kro/cmd/kro/commands/generate"
+	publish "github.com/kro-run/kro/cmd/kro/commands/publish"
 	validate "github.com/kro-run/kro/cmd/kro/commands/validate"
 )
 
 func AddCommands(root *cobra.Command) {
 	generate.AddGenerateCommands(root)
 	validate.AddValidateCommands(root)
+	publish.AddPublishCommand(root)
 }

--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,16 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.20.0
 	github.com/onsi/gomega v1.34.1
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/term v0.32.0
 	golang.org/x/time v0.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apimachinery v0.31.0
@@ -24,6 +27,7 @@ require (
 	k8s.io/client-go v0.31.0
 	k8s.io/kube-openapi v0.0.0-20240816214639-573285566f34
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/release-utils v0.11.0
 	sigs.k8s.io/yaml v1.4.0
@@ -68,6 +72,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -89,8 +94,8 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/term v0.30.0 // indirect
+	golang.org/x/sync v0.14.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
@@ -99,7 +104,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,10 @@ github.com/onsi/ginkgo/v2 v2.20.0 h1:PE84V2mHqoT1sglvHc8ZdQtPcwmvvt29WLEEO3xmdZw
 github.com/onsi/ginkgo/v2 v2.20.0/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -398,6 +402,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -434,11 +440,11 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -648,6 +654,8 @@ k8s.io/kube-openapi v0.0.0-20240816214639-573285566f34 h1:/amS69DLm09mtbFtN3+Lyy
 k8s.io/kube-openapi v0.0.0-20240816214639-573285566f34/go.mod h1:G0W3eI9gG219NHRq3h5uQaRBl4pj4ZpwzRP5ti8y770=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
## Description 

The new kro cli publish command is useful to publish an OCI image into container registries like docker hub, aws, gcr, etc....

## Usage

 `kro package -f [FILE] -r [REGISTRY_URL] -u [USER_NAME] -p [PASSWORD]`

Flags:

| Shorthand | Flag | Usage | 
| ---- | ----- | --- |
 | -f |  --file | Path to the ResourceGroupDefinition file |
 | -r |  --ref | Remote reference to publish the OCI image to (e.g., 'ghcr.io/user/repo:tag') |
 | -u  | --username | Username for the remote registry (Optional) |
 | -p | --password |  Password for the remote registry (Optional) |

**Note:** If username or password is not provided via flags the cli will prompt the user to provide them in further steps.

## Demo

[kro-publish.webm](https://github.com/user-attachments/assets/d5ff44c6-c68d-42ce-9d0f-815dbe9a56db)


  